### PR TITLE
Add Cmd+V keyboard shortcut for pasting links

### DIFF
--- a/Sources/ArcmarkCore/AppDelegate.swift
+++ b/Sources/ArcmarkCore/AppDelegate.swift
@@ -119,6 +119,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
         newFolderItem.keyEquivalentModifierMask = [.command, .shift]
         fileMenu.addItem(newFolderItem)
 
+        let editMenuItem = NSMenuItem()
+        mainMenu.addItem(editMenuItem)
+        let editMenu = NSMenu(title: "Edit")
+        editMenuItem.submenu = editMenu
+        editMenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+        editMenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "Z")
+        editMenu.addItem(NSMenuItem.separator())
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+
         let windowMenuItem = NSMenuItem()
         mainMenu.addItem(windowMenuItem)
         let windowMenu = NSMenu(title: "Window")

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -494,6 +494,10 @@ final class MainViewController: NSViewController {
         nodeListViewController.scheduleInlineRename(for: newId)
     }
 
+    @objc func paste(_ sender: Any?) {
+        pasteLink()
+    }
+
     @objc private func pasteLink() {
         guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
         let urls = extractUrls(from: pasted)


### PR DESCRIPTION
## Summary
Implements keyboard shortcut support for the existing paste links feature by adding an Edit menu with standard Paste action (Cmd+V). When the Arcmark window is focused, users can now press Cmd+V to insert links from the clipboard in addition to using the button.

## Implementation Details
- Added Edit menu with standard editing commands (Undo, Redo, Cut, Copy, Paste, Select All)
- Implemented `paste(_:)` method in MainViewController that routes to existing `pasteLink()` logic
- Uses AppKit responder chain for automatic routing: text fields get normal paste behavior, MainViewController handles link pasting when no text field is focused

## Test Plan
- ✅ Project builds successfully
- ✅ All 20 unit tests pass
- Test the feature: Focus Arcmark window and press Cmd+V with URLs in clipboard (single or multiple)
- Verify normal paste still works in text fields (search bar, inline rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)