### PR TITLE
Add context menu to edit saved link URLs

### DIFF
--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -210,6 +210,19 @@ final class AppModel {
         }
     }
 
+    func updateLinkUrl(id: UUID, newUrl: String) {
+        updateNode(id: id) { node in
+            switch node {
+            case .link(var link):
+                link.url = newUrl
+                link.faviconPath = nil
+                node = .link(link)
+            case .folder:
+                break
+            }
+        }
+    }
+
     func updateLinkTitleIfDefault(id: UUID, newTitle: String) -> Bool {
         let trimmed = newTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return false }

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -244,6 +244,10 @@ final class MainViewController: NSViewController {
         nodeListViewController.onNewFolderRequested = { [weak self] parentId in
             self?.createFolderAndBeginRename(parentId: parentId)
         }
+
+        nodeListViewController.onLinkUrlEdited = { [weak self] nodeId, newUrl in
+            self?.model.updateLinkUrl(id: nodeId, newUrl: newUrl)
+        }
     }
 
     private func bindModel() {


### PR DESCRIPTION
## Summary

Adds an "Edit URL…" context menu action for links, allowing users to modify the URL in a dialog box. The dialog pre-fills the current URL and includes Save/Cancel buttons. When saved, the favicon is automatically cleared and re-fetched for the new URL.

## Changes

- **AppModel.swift**: New `updateLinkUrl(id:newUrl:)` method that updates the link URL and clears the favicon path
- **NodeListViewController.swift**: Added callback, context menu item, and NSAlert dialog handler for editing URLs
- **MainViewController.swift**: Wired the callback to trigger model updates

## Implementation Details

The feature follows existing app patterns:
- Uses NSAlert with accessory text field (same as bulk delete confirmation)
- Communicates via callbacks between view controllers
- Mutations go through AppModel's `updateNode` mechanism with automatic persistence
- Setting `faviconPath = nil` triggers automatic favicon re-fetch on next reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)