### PR TITLE
Extract pinned tabs grid config into ThemeConstants

### DIFF
--- a/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabsView.swift
+++ b/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabsView.swift
@@ -68,7 +68,7 @@ final class PinnedTabsView: NSView {
 
         while placed < count {
             let remaining = count - placed
-            let cols = min(remaining, 3)
+            let cols = min(remaining, ThemeConstants.Sizing.pinnedTileColumns)
             let tileWidth = (totalWidth - gap * CGFloat(cols - 1)) / CGFloat(cols)
 
             for col in 0..<cols {
@@ -87,7 +87,8 @@ final class PinnedTabsView: NSView {
 
         let tileHeight = ThemeConstants.Sizing.pinnedTileHeight
         let gap = ThemeConstants.Spacing.tiny
-        let rows = Int(ceil(Double(count) / 3.0))
+        let cols = ThemeConstants.Sizing.pinnedTileColumns
+        let rows = min(Int(ceil(Double(count) / Double(cols))), ThemeConstants.Sizing.pinnedTileMaxRows)
         let height = CGFloat(rows) * tileHeight + CGFloat(rows - 1) * gap
 
         return NSSize(width: NSView.noIntrinsicMetric, height: height)

--- a/Sources/ArcmarkCore/Models.swift
+++ b/Sources/ArcmarkCore/Models.swift
@@ -29,7 +29,7 @@ struct Workspace: Codable, Identifiable, Equatable {
     var items: [Node]
     var pinnedLinks: [Link]
 
-    static let maxPinnedLinks = 9
+    static let maxPinnedLinks = ThemeConstants.Sizing.pinnedTileColumns * ThemeConstants.Sizing.pinnedTileMaxRows
 
     init(id: UUID, name: String, colorId: WorkspaceColorId, items: [Node], pinnedLinks: [Link] = []) {
         self.id = id

--- a/Sources/ArcmarkCore/Utilities/Theme/ThemeConstants.swift
+++ b/Sources/ArcmarkCore/Utilities/Theme/ThemeConstants.swift
@@ -243,6 +243,12 @@ struct ThemeConstants {
         static let rowHeight: CGFloat = 44
 
         static let pinnedTileHeight: CGFloat = 50
+
+        /// Number of columns in the pinned tabs grid
+        static let pinnedTileColumns: Int = 4
+
+        /// Maximum number of rows in the pinned tabs grid
+        static let pinnedTileMaxRows: Int = 3
     }
 
     // MARK: - Animation

--- a/Tests/ArcmarkTests/ModelTests.swift
+++ b/Tests/ArcmarkTests/ModelTests.swift
@@ -164,23 +164,24 @@ final class ModelTests: XCTestCase {
         store.save(DataStore.defaultState())
         let model = AppModel(store: store)
 
+        let max = Workspace.maxPinnedLinks
         var linkIds: [UUID] = []
-        for i in 0..<10 {
+        for i in 0..<(max + 1) {
             let id = model.addLink(urlString: "https://\(i).com", title: "Link \(i)", parentId: nil)
             linkIds.append(id)
         }
 
-        // Pin 9 links (the maximum)
-        for i in 0..<9 {
+        // Pin up to the maximum
+        for i in 0..<max {
             model.pinLink(id: linkIds[i])
         }
-        XCTAssertEqual(model.currentWorkspace.pinnedLinks.count, 9)
+        XCTAssertEqual(model.currentWorkspace.pinnedLinks.count, max)
         XCTAssertEqual(model.currentWorkspace.items.count, 1)
         XCTAssertFalse(model.canPinMore)
 
-        // Attempt to pin the 10th - should be rejected
-        model.pinLink(id: linkIds[9])
-        XCTAssertEqual(model.currentWorkspace.pinnedLinks.count, 9)
+        // Attempt to pin one more - should be rejected
+        model.pinLink(id: linkIds[max])
+        XCTAssertEqual(model.currentWorkspace.pinnedLinks.count, max)
         XCTAssertEqual(model.currentWorkspace.items.count, 1)
     }
 


### PR DESCRIPTION
## Summary

Move hardcoded pinned tabs grid configuration into ThemeConstants to make the layout configurable. Added `pinnedTileColumns` (4) and `pinnedTileMaxRows` (3) to enable easy tweaking of grid dimensions from the design system. `Workspace.maxPinnedLinks` now derives from these constants (4×3=12) to stay in sync.

## Changes

- ThemeConstants.Sizing: Add `pinnedTileColumns` and `pinnedTileMaxRows` constants
- PinnedTabsView: Replace hardcoded column count with `ThemeConstants.Sizing.pinnedTileColumns`
- PinnedTabsView: Replace hardcoded max rows calculation with `ThemeConstants.Sizing.pinnedTileMaxRows`
- Models: Derive `maxPinnedLinks` from theme constants instead of hardcoding
- ModelTests: Update pin link maximum test to use `Workspace.maxPinnedLinks` instead of hardcoded values

## Test Status

All 34 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)