### PR TITLE
Fix Sparkle update failure: patch SUPublicEDKey from Bundler.toml

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -49,6 +49,24 @@ if ! /usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$INFO_PLIST" &>/dev
     /usr/libexec/PlistBuddy -c "Add :CFBundleIdentifier string 'com.arcmark.app'" "$INFO_PLIST"
 fi
 
+# Patch Sparkle keys (Swift Bundler doesn't reliably merge [apps.*.plist] values)
+FEED_URL="https://geek-1001.github.io/arcmark/appcast.xml"
+PUBLIC_ED_KEY=$(grep "^SUPublicEDKey" Bundler.toml | sed "s/.*= *'\\(.*\\)'/\\1/" | tr -d '[:space:]')
+
+if ! /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$INFO_PLIST" &>/dev/null; then
+    /usr/libexec/PlistBuddy -c "Add :SUFeedURL string '$FEED_URL'" "$INFO_PLIST"
+else
+    /usr/libexec/PlistBuddy -c "Set :SUFeedURL '$FEED_URL'" "$INFO_PLIST"
+fi
+
+if [ -n "$PUBLIC_ED_KEY" ]; then
+    if ! /usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$INFO_PLIST" &>/dev/null; then
+        /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string '$PUBLIC_ED_KEY'" "$INFO_PLIST"
+    else
+        /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey '$PUBLIC_ED_KEY'" "$INFO_PLIST"
+    fi
+fi
+
 # Add @executable_path/../Frameworks to rpath so dyld can find embedded frameworks
 EXECUTABLE=".build/bundler/Arcmark.app/Contents/MacOS/Arcmark"
 if ! otool -l "$EXECUTABLE" | grep -A2 LC_RPATH | grep -q '@executable_path/../Frameworks'; then


### PR DESCRIPTION
## Summary

Fixes the "updater failed to start" error by ensuring `SUPublicEDKey` is properly set in the app's Info.plist. The build scripts now read the actual EdDSA key from Bundler.toml and explicitly patch it into Info.plist, instead of adding an empty string placeholder.

## Root Cause

Swift Bundler's `[apps.*.plist]` merging is unreliable. When it failed to merge `SUPublicEDKey` from Bundler.toml, the build script added an empty string instead of the actual key. Sparkle rejected the empty key during validation, causing the updater to fail.

## Changes

- **scripts/build.sh**: Extract SUPublicEDKey from Bundler.toml and use PlistBuddy to explicitly set it (same pattern as version strings and SUFeedURL)
- **scripts/run.sh**: Apply the same Sparkle key patching for development builds

This ensures both Sparkle keys (SUFeedURL and SUPublicEDKey) are always correctly set regardless of Swift Bundler's plist merging behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)