### PR TITLE
Add top/bottom overscroll shadows to workspace items list

### DIFF
--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -354,6 +354,7 @@ final class MainViewController: NSViewController {
     private func applyWorkspaceStyling() {
         view.layer?.backgroundColor = model.currentWorkspace.colorId.backgroundColor.cgColor
         view.window?.backgroundColor = model.currentWorkspace.colorId.backgroundColor
+        nodeListViewController.workspaceColor = model.currentWorkspace.colorId
     }
 
     private func showSettingsContent() {

--- a/Sources/ArcmarkCore/Utilities/Theme/ThemeConstants.swift
+++ b/Sources/ArcmarkCore/Utilities/Theme/ThemeConstants.swift
@@ -244,6 +244,12 @@ struct ThemeConstants {
 
         static let pinnedTileHeight: CGFloat = 50
 
+        /// Scroll shadow gradient height (32pt) - Used for vertical overscroll fade indicators
+        static let scrollShadowHeight: CGFloat = 32
+
+        /// Scroll shadow gradient width (32pt) - Used for horizontal overscroll fade indicators
+        static let scrollShadowWidth: CGFloat = 32
+
         /// Number of columns in the pinned tabs grid
         static let pinnedTileColumns: Int = 4
 

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -13,6 +13,8 @@ final class NodeListViewController: NSViewController {
 
     fileprivate let collectionView = ContextMenuCollectionView()
     let scrollView = NSScrollView()
+    private let topShadowView = NSView()
+    private let bottomShadowView = NSView()
     private let dropIndicator = DropIndicatorView()
     private let listMetrics = ListMetrics()
     private let contextMenu = NSMenu()
@@ -59,6 +61,11 @@ final class NodeListViewController: NSViewController {
 
     // State
     var isSearchActive: Bool = false
+    var workspaceColor: WorkspaceColorId = .defaultColor() {
+        didSet {
+            updateShadows()
+        }
+    }
 
     // MARK: - Initialization
 
@@ -131,12 +138,33 @@ final class NodeListViewController: NSViewController {
 
         view.addSubview(scrollView)
 
+        // Setup shadow views
+        topShadowView.translatesAutoresizingMaskIntoConstraints = false
+        topShadowView.wantsLayer = true
+        bottomShadowView.translatesAutoresizingMaskIntoConstraints = false
+        bottomShadowView.wantsLayer = true
+
+        view.addSubview(topShadowView)
+        view.addSubview(bottomShadowView)
+
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+            topShadowView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            topShadowView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            topShadowView.topAnchor.constraint(equalTo: view.topAnchor),
+            topShadowView.heightAnchor.constraint(equalToConstant: ThemeConstants.Sizing.scrollShadowHeight),
+
+            bottomShadowView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bottomShadowView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomShadowView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            bottomShadowView.heightAnchor.constraint(equalToConstant: ThemeConstants.Sizing.scrollShadowHeight)
         ])
+
+        updateShadows()
     }
 
     private func setupNotifications() {
@@ -187,9 +215,59 @@ final class NodeListViewController: NSViewController {
 
     // MARK: - Private Methods
 
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        updateShadows()
+    }
+
     @objc private func handleScrollBoundsChanged() {
+        updateShadows()
         for item in collectionView.visibleItems() {
             (item as? NodeCollectionViewItem)?.refreshHoverState()
+        }
+    }
+
+    private func updateShadows() {
+        let clipView = scrollView.contentView
+        let visibleRect = clipView.documentVisibleRect
+        let contentHeight = collectionView.bounds.height
+
+        let canScrollUp = visibleRect.origin.y > 0
+        let canScrollDown = visibleRect.origin.y + visibleRect.height < contentHeight
+
+        let baseColor = workspaceColor.backgroundColor
+        let shadowOpacity = ThemeConstants.Opacity.high
+
+        if canScrollUp {
+            let topGradient = CAGradientLayer()
+            topGradient.frame = topShadowView.bounds
+            topGradient.colors = [
+                baseColor.withAlphaComponent(0.0).cgColor,
+                baseColor.withAlphaComponent(shadowOpacity).cgColor
+            ]
+            topGradient.startPoint = CGPoint(x: 0.5, y: 0)
+            topGradient.endPoint = CGPoint(x: 0.5, y: 1)
+            topShadowView.layer?.sublayers?.forEach { $0.removeFromSuperlayer() }
+            topShadowView.layer?.addSublayer(topGradient)
+            topShadowView.isHidden = false
+        } else {
+            topShadowView.isHidden = true
+        }
+
+        if canScrollDown {
+            let bottomGradient = CAGradientLayer()
+            bottomGradient.frame = bottomShadowView.bounds
+            bottomGradient.colors = [
+                baseColor.withAlphaComponent(shadowOpacity).cgColor,
+                baseColor.withAlphaComponent(0.0).cgColor
+            ]
+            bottomGradient.startPoint = CGPoint(x: 0.5, y: 0)
+            bottomGradient.endPoint = CGPoint(x: 0.5, y: 1)
+            bottomShadowView.layer?.sublayers?.forEach { $0.removeFromSuperlayer() }
+            bottomShadowView.layer?.addSublayer(bottomGradient)
+            bottomShadowView.isHidden = false
+        } else {
+            bottomShadowView.isHidden = true
         }
     }
 

--- a/Sources/ArcmarkCore/WorkspaceSwitcherView.swift
+++ b/Sources/ArcmarkCore/WorkspaceSwitcherView.swift
@@ -158,12 +158,12 @@ final class WorkspaceSwitcherView: NSView {
             leftShadowView.leadingAnchor.constraint(equalTo: leadingAnchor),
             leftShadowView.topAnchor.constraint(equalTo: topAnchor),
             leftShadowView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            leftShadowView.widthAnchor.constraint(equalToConstant: 32),
+            leftShadowView.widthAnchor.constraint(equalToConstant: ThemeConstants.Sizing.scrollShadowWidth),
 
             rightShadowView.trailingAnchor.constraint(equalTo: trailingAnchor),
             rightShadowView.topAnchor.constraint(equalTo: topAnchor),
             rightShadowView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            rightShadowView.widthAnchor.constraint(equalToConstant: 32)
+            rightShadowView.widthAnchor.constraint(equalToConstant: ThemeConstants.Sizing.scrollShadowWidth)
         ])
 
         NotificationCenter.default.addObserver(
@@ -313,13 +313,13 @@ final class WorkspaceSwitcherView: NSView {
         // Create gradients based on workspace color
         let baseColor = workspaceColor.color
 
-        let shadowGradientOpacity = 0.80
+        let shadowOpacity = ThemeConstants.Opacity.high
 
         if canScrollLeft {
             let leftGradient = CAGradientLayer()
             leftGradient.frame = leftShadowView.bounds
             leftGradient.colors = [
-                baseColor.withAlphaComponent(shadowGradientOpacity).cgColor,
+                baseColor.withAlphaComponent(shadowOpacity).cgColor,
                 baseColor.withAlphaComponent(0.0).cgColor
             ]
             leftGradient.startPoint = CGPoint(x: 0, y: 0.5)
@@ -336,7 +336,7 @@ final class WorkspaceSwitcherView: NSView {
             rightGradient.frame = rightShadowView.bounds
             rightGradient.colors = [
                 baseColor.withAlphaComponent(0.0).cgColor,
-                baseColor.withAlphaComponent(shadowGradientOpacity).cgColor
+                baseColor.withAlphaComponent(shadowOpacity).cgColor
             ]
             rightGradient.startPoint = CGPoint(x: 0, y: 0.5)
             rightGradient.endPoint = CGPoint(x: 1, y: 0.5)


### PR DESCRIPTION
## Summary
Implement gradient shadow indicators at the top and bottom of the node list that fade in when there is more content to scroll in that direction. This mirrors the existing horizontal scroll shadows in WorkspaceSwitcherView.

## Changes
- Add topShadowView and bottomShadowView to NodeListViewController with vertical gradient layers
- Add workspaceColor property to pass theme color from MainViewController
- Update shadows on scroll events and layout changes
- Add scrollShadowHeight and scrollShadowWidth constants to ThemeConstants.Sizing for reusability
- Use ThemeConstants.Opacity.high (0.80) for shadow gradient opacity for design consistency
- Update WorkspaceSwitcherView to use new theme constants instead of hardcoded values

## Technical Details
- Shadows only appear when content can scroll in that direction (hide at extremes)
- Uses workspace background color with high opacity fading to transparent
- 32pt shadow height for vertical and horizontal scroll indicators
- Pattern mirrors existing WorkspaceSwitcherView implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)