### PR TITLE
Support emoji in workspace names

### DIFF
--- a/Sources/ArcmarkCore/Components/Base/InlineEditableTextField.swift
+++ b/Sources/ArcmarkCore/Components/Base/InlineEditableTextField.swift
@@ -82,6 +82,9 @@ final class InlineEditableTextField: NSView {
         set { textField.stringValue = newValue }
     }
 
+    /// Commits edits when focus leaves the field (except explicit cancel movement).
+    var commitsOnFocusLoss = false
+
     /// Indicates whether the text field is currently in edit mode.
     var isEditing: Bool {
         isEditingTitle
@@ -215,7 +218,10 @@ extension InlineEditableTextField: NSTextFieldDelegate {
         let movement = obj.userInfo?["NSTextMovement"] as? Int ?? NSOtherTextMovement
         let trimmed = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        if movement == NSReturnTextMovement, !trimmed.isEmpty {
+        let isEscapeOrCancel = movement == NSCancelTextMovement
+        let shouldCommit = !trimmed.isEmpty && (movement == NSReturnTextMovement || (commitsOnFocusLoss && !isEscapeOrCancel))
+
+        if shouldCommit {
             textField.stringValue = trimmed
             finishInlineRename(commit: true)
         } else {

--- a/Sources/ArcmarkCore/WorkspaceRowView.swift
+++ b/Sources/ArcmarkCore/WorkspaceRowView.swift
@@ -110,6 +110,7 @@ final class WorkspaceRowView: BaseView {
         editableTitle.translatesAutoresizingMaskIntoConstraints = false
         editableTitle.font = style.titleFont
         editableTitle.textColor = style.titleColor
+        editableTitle.commitsOnFocusLoss = true
 
         // Delete button
         deleteButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/ArcmarkCore/WorkspaceSwitcherView.swift
+++ b/Sources/ArcmarkCore/WorkspaceSwitcherView.swift
@@ -670,8 +670,10 @@ extension WorkspaceButton: NSTextFieldDelegate {
         guard isEditingTitle else { return }
         let movement = obj.userInfo?["NSTextMovement"] as? Int ?? NSOtherTextMovement
         let trimmed = titleLabel.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isEscapeOrCancel = movement == NSCancelTextMovement
+        let shouldCommit = !trimmed.isEmpty && (movement == NSReturnTextMovement || !isEscapeOrCancel)
 
-        if movement == NSReturnTextMovement, !trimmed.isEmpty {
+        if shouldCommit {
             titleLabel.stringValue = trimmed
             finishInlineRename(commit: true)
         } else {
@@ -680,4 +682,3 @@ extension WorkspaceButton: NSTextFieldDelegate {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
Workspace rename currently fails in common emoji-entry flows. When users open the macOS emoji picker (`Ctrl+Cmd+Space`) while renaming a workspace, the field can lose focus and the edit gets canceled instead of saved.

This change allows workspace renames to commit on focus loss (while still cancelling on explicit cancel movement), so emoji characters can be inserted and persisted reliably.

## Root Cause
Workspace inline rename logic only committed when editing ended with `NSReturnTextMovement`.
Any other end-editing movement was treated as cancel, which includes focus changes that happen during emoji picker interactions.

## Changes
- Added a configurable `commitsOnFocusLoss` behavior to `/Users/vaibhavsomani/Desktop/Projects/personal/arcmark/Sources/ArcmarkCore/Components/Base/InlineEditableTextField.swift`.
- Enabled `commitsOnFocusLoss` for workspace rows in `/Users/vaibhavsomani/Desktop/Projects/personal/arcmark/Sources/ArcmarkCore/WorkspaceRowView.swift`.
- Updated workspace switcher inline rename commit logic in `/Users/vaibhavsomani/Desktop/Projects/personal/arcmark/Sources/ArcmarkCore/WorkspaceSwitcherView.swift` to commit on non-cancel focus-loss events.

## User Impact
- Users can now add emoji to workspace names without losing edits.
- Existing cancel behavior is preserved for explicit cancel movement.
- Empty/whitespace-only names still do not commit.

## Validation
- `swift build -c release`
- `./scripts/run.sh`
- `./scripts/verify-build.sh .build/bundler/Arcmark.app`
- Runtime check: `osascript -e 'application "Arcmark" is running'` returned `true`
