### PR TITLE
fix: hide tooltip during drag-and-drop reordering

### DIFF
--- a/Sources/ArcmarkCore/NodeRowView.swift
+++ b/Sources/ArcmarkCore/NodeRowView.swift
@@ -12,6 +12,7 @@ final class NodeRowView: BaseView {
     private var tooltipShowTask: DispatchWorkItem?
     private static let sharedTooltip = CustomTooltipView()
     private static weak var activeTooltipTask: DispatchWorkItem?
+    static var isDragging = false
     private var iconLeadingConstraint: NSLayoutConstraint?
     private var iconWidthConstraint: NSLayoutConstraint?
     private var iconHeightConstraint: NSLayoutConstraint?
@@ -155,7 +156,7 @@ final class NodeRowView: BaseView {
         tooltipShowTask?.cancel()
         tooltipShowTask = nil
 
-        if isHovered,
+        if isHovered, !NodeRowView.isDragging,
            let url = tooltipURL, !url.isEmpty,
            UserDefaults.standard.bool(forKey: UserDefaultsKeys.tooltipsEnabled) {
             let task = DispatchWorkItem { [weak self] in

--- a/Sources/ArcmarkCore/SwipeGestureService.swift
+++ b/Sources/ArcmarkCore/SwipeGestureService.swift
@@ -13,12 +13,12 @@ protocol SwipeGestureServiceDelegate: AnyObject {
 }
 
 /// Detects horizontal trackpad swipes via global+local NSEvent monitors.
-/// Not @MainActor so event monitor callbacks can access state synchronously
-/// (event monitors always run on main thread).
-final class SwipeGestureService: @unchecked Sendable {
-    @MainActor static let shared = SwipeGestureService()
+/// Event monitors always run on the main thread, so @MainActor is safe here.
+@MainActor
+final class SwipeGestureService {
+    static let shared = SwipeGestureService()
 
-    @MainActor weak var delegate: SwipeGestureServiceDelegate?
+    weak var delegate: SwipeGestureServiceDelegate?
 
     private var globalMonitor: Any?
     private var localMonitor: Any?
@@ -42,12 +42,10 @@ final class SwipeGestureService: @unchecked Sendable {
     private init() {}
 
     /// Registers a view whose area should be excluded from swipe gesture detection.
-    @MainActor
     func addExcludedView(_ view: NSView) {
         excludedViews.append(WeakView(view: view))
     }
 
-    @MainActor
     func enable(window: NSWindow) {
         self.window = window
         disable()
@@ -71,7 +69,6 @@ final class SwipeGestureService: @unchecked Sendable {
         }
     }
 
-    @MainActor
     func disable() {
         if let globalMonitor {
             NSEvent.removeMonitor(globalMonitor)
@@ -175,13 +172,9 @@ final class SwipeGestureService: @unchecked Sendable {
         hasTriggered = false
     }
 
-    /// Dispatches delegate calls on MainActor. Since event monitors run on
-    /// the main thread, this executes synchronously via assumeIsolated.
-    private func notifyDelegate(_ body: @escaping @MainActor (SwipeGestureServiceDelegate) -> Void) {
-        MainActor.assumeIsolated {
-            guard let delegate = self.delegate else { return }
-            body(delegate)
-        }
+    private func notifyDelegate(_ body: (SwipeGestureServiceDelegate) -> Void) {
+        guard let delegate else { return }
+        body(delegate)
     }
 }
 

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -691,6 +691,8 @@ extension NodeListViewController: NSCollectionViewDelegate {
                         willBeginAt screenPoint: NSPoint,
                         forItemsAt indexPaths: Set<IndexPath>) {
         isDraggingItems = true
+        NodeRowView.isDragging = true
+        NodeRowView.hideSharedTooltip()
     }
 
     func collectionView(_ collectionView: NSCollectionView,
@@ -698,6 +700,7 @@ extension NodeListViewController: NSCollectionViewDelegate {
                         endedAt screenPoint: NSPoint,
                         dragOperation operation: NSDragOperation) {
         isDraggingItems = false
+        NodeRowView.isDragging = false
         hideDropIndicator()
     }
 


### PR DESCRIPTION
## Summary
Tooltips now remain hidden while dragging links or folders to reorder them, providing a cleaner drag-and-drop experience.

## Changes
- Added static `isDragging` flag to `NodeRowView` to track drag state
- Suppressed tooltip display when dragging is active
- Immediately hide any visible tooltip when drag starts
- Refactored `SwipeGestureService` to use `@MainActor` annotation instead of `@unchecked Sendable`, simplifying concurrency handling

## Testing
- Built and ran all tests successfully (15 tests pass)
- Verified that tooltips are suppressed during drag operations