### PR TITLE
fix: use snapshot-based animation for workspace swipe cancel

### DIFF
--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -912,14 +912,31 @@ extension MainViewController: SwipeGestureServiceDelegate {
         swipeClipContainer.addSubview(currentSnapshotView)
         swipeClipContainer.addSubview(incomingSnapshotView)
 
-        // Animate both snapshots: current slides out, incoming slides in
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = ThemeConstants.Animation.durationNormal
-            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
-            context.allowsImplicitAnimation = true
-            currentSnapshotView.animator().frame.origin.x = slideOffX
-            incomingSnapshotView.animator().frame.origin.x = 0
-        }, completionHandler: { [weak self] in
+        // Animate both snapshots with spring physics (matches edge bounce feel)
+        let currentSpring = CASpringAnimation(keyPath: "position.x")
+        currentSpring.fromValue = currentSnapshotView.layer!.position.x
+        currentSpring.toValue = slideOffX + containerWidth / 2
+        currentSpring.mass = 1.0
+        currentSpring.stiffness = 400
+        currentSpring.damping = 22
+        currentSpring.initialVelocity = 0
+        currentSpring.duration = currentSpring.settlingDuration
+        currentSpring.isRemovedOnCompletion = false
+        currentSpring.fillMode = .forwards
+
+        let incomingSpring = CASpringAnimation(keyPath: "position.x")
+        incomingSpring.fromValue = incomingSnapshotView.layer!.position.x
+        incomingSpring.toValue = containerWidth / 2
+        incomingSpring.mass = 1.0
+        incomingSpring.stiffness = 400
+        incomingSpring.damping = 22
+        incomingSpring.initialVelocity = 0
+        incomingSpring.duration = incomingSpring.settlingDuration
+        incomingSpring.isRemovedOnCompletion = false
+        incomingSpring.fillMode = .forwards
+
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
             guard let self else { return }
 
             // Remove snapshots
@@ -952,7 +969,10 @@ extension MainViewController: SwipeGestureServiceDelegate {
             self.workspaceContentStack.isHidden = false
             self.suppressNodeAnimations = false
             self.isSwipeAnimating = false
-        })
+        }
+        currentSnapshotView.layer!.add(currentSpring, forKey: "swipeTransition")
+        incomingSnapshotView.layer!.add(incomingSpring, forKey: "swipeTransition")
+        CATransaction.commit()
     }
 
     func swipeGestureDidCancel(_ service: SwipeGestureService) {

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -841,6 +841,7 @@ extension MainViewController: SwipeGestureServiceDelegate {
         guard let layer = workspaceContentStack.layer else { return }
 
         let containerWidth = swipeClipContainer.bounds.width
+        let containerHeight = swipeClipContainer.bounds.height
 
         // Determine if we can actually navigate
         let canNavigate: Bool
@@ -855,7 +856,6 @@ extension MainViewController: SwipeGestureServiceDelegate {
         }
 
         isSwipeAnimating = true
-        let slideOffX: CGFloat = direction == .right ? containerWidth : -containerWidth
 
         // Save current color so applyWorkspaceStyling can animate the transition
         let currentBgColor: NSColor
@@ -865,23 +865,74 @@ extension MainViewController: SwipeGestureServiceDelegate {
             currentBgColor = model.currentWorkspace.colorId.backgroundColor
         }
 
-        // Animate content sliding off-screen
+        // --- Snapshot-based animation ---
+        // Capture a snapshot of the current workspace content at its current drag position
+        let currentSnapshotView = NSView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+        currentSnapshotView.wantsLayer = true
+        let contentBounds = workspaceContentStack.bounds
+        if let bitmap = workspaceContentStack.bitmapImageRepForCachingDisplay(in: contentBounds) {
+            workspaceContentStack.cacheDisplay(in: contentBounds, to: bitmap)
+            let image = NSImage(size: contentBounds.size)
+            image.addRepresentation(bitmap)
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+            imageView.imageScaling = .scaleNone
+            imageView.imageAlignment = .alignTopLeft
+            imageView.image = image
+            currentSnapshotView.addSubview(imageView)
+        }
+
+        // Build the incoming snapshot from the already-captured preview
+        let incomingSnapshotView = NSView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+        incomingSnapshotView.wantsLayer = true
+        if let previewImage = swipePreviewSnapshot {
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+            imageView.imageScaling = .scaleNone
+            imageView.imageAlignment = .alignTopLeft
+            imageView.image = previewImage
+            incomingSnapshotView.addSubview(imageView)
+        }
+
+        // Capture current drag offset before resetting
+        let currentOffset = layer.presentation()?.transform.m41 ?? layer.transform.m41
+        let slideOffX: CGFloat = direction == .right ? containerWidth : -containerWidth
+        let incomingStartX: CGFloat = direction == .right ? currentOffset - containerWidth : currentOffset + containerWidth
+
+        // Remove the drag preview and reset the real content layer
+        removeSwipePreview()
         CATransaction.begin()
-        CATransaction.setAnimationDuration(ThemeConstants.Animation.durationNormal)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeIn))
-        CATransaction.setCompletionBlock { [weak self] in
+        CATransaction.setDisableActions(true)
+        layer.transform = CATransform3DIdentity
+        CATransaction.commit()
+
+        // Hide the real content and place snapshots in the clip container
+        workspaceContentStack.isHidden = true
+
+        currentSnapshotView.frame.origin.x = currentOffset
+        incomingSnapshotView.frame.origin.x = incomingStartX
+        swipeClipContainer.addSubview(currentSnapshotView)
+        swipeClipContainer.addSubview(incomingSnapshotView)
+
+        // Animate both snapshots: current slides out, incoming slides in
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = ThemeConstants.Animation.durationNormal
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            context.allowsImplicitAnimation = true
+            currentSnapshotView.animator().frame.origin.x = slideOffX
+            incomingSnapshotView.animator().frame.origin.x = 0
+        }, completionHandler: { [weak self] in
             guard let self else { return }
 
-            // Remove preview before switching
-            self.removeSwipePreview()
+            // Remove snapshots
+            currentSnapshotView.removeFromSuperview()
+            incomingSnapshotView.removeFromSuperview()
 
             // Set the from-color so reloadData → applyWorkspaceStyling animates the color
             self.swipeColorAnimationFromColor = currentBgColor
 
-            // Suppress collection view animations — the slide animation handles the transition
+            // Suppress collection view animations — we already animated via snapshots
             self.suppressNodeAnimations = true
 
-            // Suppress async onChange to prevent mid-animation content snap
+            // Suppress async onChange to prevent extra reload
             let savedOnChange = self.model.onChange
             self.model.onChange = nil
 
@@ -891,31 +942,17 @@ extension MainViewController: SwipeGestureServiceDelegate {
             case .left: self.navigateToNextWorkspace()
             }
 
-            // Synchronously update UI while content is off-screen
+            // Synchronously update UI with new workspace data
             self.reloadData()
 
             // Restore onChange for future state changes
             self.model.onChange = savedOnChange
 
-            // Position on opposite side
-            CATransaction.begin()
-            CATransaction.setDisableActions(true)
-            layer.transform = CATransform3DMakeTranslation(-slideOffX, 0, 0)
-            CATransaction.commit()
-
-            // Animate sliding in
-            CATransaction.begin()
-            CATransaction.setAnimationDuration(ThemeConstants.Animation.durationNormal)
-            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-            CATransaction.setCompletionBlock { [weak self] in
-                self?.suppressNodeAnimations = false
-                self?.isSwipeAnimating = false
-            }
-            layer.transform = CATransform3DIdentity
-            CATransaction.commit()
-        }
-        layer.transform = CATransform3DMakeTranslation(slideOffX, 0, 0)
-        CATransaction.commit()
+            // Show the real content (now displaying new workspace)
+            self.workspaceContentStack.isHidden = false
+            self.suppressNodeAnimations = false
+            self.isSwipeAnimating = false
+        })
     }
 
     func swipeGestureDidCancel(_ service: SwipeGestureService) {

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -881,11 +881,21 @@ extension MainViewController: SwipeGestureServiceDelegate {
             // Suppress collection view animations — the slide animation handles the transition
             self.suppressNodeAnimations = true
 
+            // Suppress async onChange to prevent mid-animation content snap
+            let savedOnChange = self.model.onChange
+            self.model.onChange = nil
+
             // Switch workspace
             switch direction {
             case .right: self.navigateToPreviousWorkspace()
             case .left: self.navigateToNextWorkspace()
             }
+
+            // Synchronously update UI while content is off-screen
+            self.reloadData()
+
+            // Restore onChange for future state changes
+            self.model.onChange = savedOnChange
 
             // Position on opposite side
             CATransaction.begin()

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -981,15 +981,68 @@ extension MainViewController: SwipeGestureServiceDelegate {
         guard let layer = workspaceContentStack.layer else { return }
         isSwipeAnimating = true
 
-        CATransaction.begin()
-        CATransaction.setAnimationDuration(ThemeConstants.Animation.durationSlow)
-        CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeOut))
-        CATransaction.setCompletionBlock { [weak self] in
-            self?.isSwipeAnimating = false
-            self?.removeSwipePreview()
+        let containerWidth = swipeClipContainer.bounds.width
+        let containerHeight = swipeClipContainer.bounds.height
+        let currentOffset = layer.presentation()?.transform.m41 ?? layer.transform.m41
+
+        // Capture snapshot of current workspace content
+        let contentSnapshotView = NSView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+        contentSnapshotView.wantsLayer = true
+        let contentBounds = workspaceContentStack.bounds
+        if let bitmap = workspaceContentStack.bitmapImageRepForCachingDisplay(in: contentBounds) {
+            workspaceContentStack.cacheDisplay(in: contentBounds, to: bitmap)
+            let image = NSImage(size: contentBounds.size)
+            image.addRepresentation(bitmap)
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+            imageView.imageScaling = .scaleNone
+            imageView.imageAlignment = .alignTopLeft
+            imageView.image = image
+            contentSnapshotView.addSubview(imageView)
         }
+
+        // Build snapshot of adjacent workspace preview
+        let previewSnapshotView = NSView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+        previewSnapshotView.wantsLayer = true
+        if let previewImage = swipePreviewSnapshot {
+            let imageView = NSImageView(frame: NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight))
+            imageView.imageScaling = .scaleNone
+            imageView.imageAlignment = .alignTopLeft
+            imageView.image = previewImage
+            previewSnapshotView.addSubview(imageView)
+        }
+
+        // Reset real content and remove preview
+        removeSwipePreview()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         layer.transform = CATransform3DIdentity
         CATransaction.commit()
+        workspaceContentStack.isHidden = true
+
+        // Position snapshots at current visual positions
+        contentSnapshotView.frame.origin.x = currentOffset
+        let previewStartX: CGFloat = currentOffset > 0
+            ? currentOffset - containerWidth  // preview is to the left
+            : currentOffset + containerWidth   // preview is to the right
+        previewSnapshotView.frame.origin.x = previewStartX
+
+        swipeClipContainer.addSubview(previewSnapshotView)
+        swipeClipContainer.addSubview(contentSnapshotView)
+
+        // Animate: content slides back to origin, preview slides off-screen
+        let previewEndX: CGFloat = currentOffset > 0 ? -containerWidth : containerWidth
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = ThemeConstants.Animation.durationFast
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            context.allowsImplicitAnimation = true
+            contentSnapshotView.animator().frame.origin.x = 0
+            previewSnapshotView.animator().frame.origin.x = previewEndX
+        }, completionHandler: { [weak self] in
+            contentSnapshotView.removeFromSuperview()
+            previewSnapshotView.removeFromSuperview()
+            self?.workspaceContentStack.isHidden = false
+            self?.isSwipeAnimating = false
+        })
     }
 
     /// Spring bounce used when swiping at an edge with no adjacent workspace.

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -912,31 +912,14 @@ extension MainViewController: SwipeGestureServiceDelegate {
         swipeClipContainer.addSubview(currentSnapshotView)
         swipeClipContainer.addSubview(incomingSnapshotView)
 
-        // Animate both snapshots with spring physics (matches edge bounce feel)
-        let currentSpring = CASpringAnimation(keyPath: "position.x")
-        currentSpring.fromValue = currentSnapshotView.layer!.position.x
-        currentSpring.toValue = slideOffX + containerWidth / 2
-        currentSpring.mass = 1.0
-        currentSpring.stiffness = 400
-        currentSpring.damping = 22
-        currentSpring.initialVelocity = 0
-        currentSpring.duration = currentSpring.settlingDuration
-        currentSpring.isRemovedOnCompletion = false
-        currentSpring.fillMode = .forwards
-
-        let incomingSpring = CASpringAnimation(keyPath: "position.x")
-        incomingSpring.fromValue = incomingSnapshotView.layer!.position.x
-        incomingSpring.toValue = containerWidth / 2
-        incomingSpring.mass = 1.0
-        incomingSpring.stiffness = 400
-        incomingSpring.damping = 22
-        incomingSpring.initialVelocity = 0
-        incomingSpring.duration = incomingSpring.settlingDuration
-        incomingSpring.isRemovedOnCompletion = false
-        incomingSpring.fillMode = .forwards
-
-        CATransaction.begin()
-        CATransaction.setCompletionBlock { [weak self] in
+        // Animate both snapshots: current slides out, incoming slides in
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = ThemeConstants.Animation.durationNormal
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            context.allowsImplicitAnimation = true
+            currentSnapshotView.animator().frame.origin.x = slideOffX
+            incomingSnapshotView.animator().frame.origin.x = 0
+        }, completionHandler: { [weak self] in
             guard let self else { return }
 
             // Remove snapshots
@@ -969,10 +952,7 @@ extension MainViewController: SwipeGestureServiceDelegate {
             self.workspaceContentStack.isHidden = false
             self.suppressNodeAnimations = false
             self.isSwipeAnimating = false
-        }
-        currentSnapshotView.layer!.add(currentSpring, forKey: "swipeTransition")
-        incomingSnapshotView.layer!.add(incomingSpring, forKey: "swipeTransition")
-        CATransaction.commit()
+        })
     }
 
     func swipeGestureDidCancel(_ service: SwipeGestureService) {


### PR DESCRIPTION
Improves the animation when a swipe gesture is cancelled (incomplete swipe with no adjacent workspace). Uses snapshot-based rendering to ensure smooth, lag-free transitions that don't depend on real-time collection view updates.

Both `swipeGestureDidComplete` and `animateSnapBack` now capture bitmap snapshots of the current and incoming workspace content, then animate these snapshots in the clip container while the real content updates off-screen. This eliminates rendering artifacts and provides consistent, fluid animations across all workspace transitions.

- Snapshot-based cancel animation (snap-back to origin)
- Matching animation style with completion animations
- Proper state management during animations
- Unchanged underlying swipe gesture detection