### PR TITLE
Add custom icon picker with emoji, SF Symbol, and favicon support

### DIFF
--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -293,6 +293,25 @@ final class AppModel {
         }
     }
 
+    func setLinkCustomIcon(id: UUID, icon: CustomIcon?) {
+        updateNode(id: id) { node in
+            switch node {
+            case .link(var link):
+                link.customIcon = icon
+                node = .link(link)
+            case .folder:
+                break
+            }
+        }
+    }
+
+    func setPinnedLinkCustomIcon(id: UUID, icon: CustomIcon?) {
+        updateWorkspace(id: currentWorkspace.id) { workspace in
+            guard let index = workspace.pinnedLinks.firstIndex(where: { $0.id == id }) else { return }
+            workspace.pinnedLinks[index].customIcon = icon
+        }
+    }
+
     func location(of nodeId: UUID) -> NodeLocation? {
         findNodeLocation(id: nodeId, nodes: currentWorkspace.items)
     }

--- a/Sources/ArcmarkCore/Components/IconPicker/IconPickerConstants.swift
+++ b/Sources/ArcmarkCore/Components/IconPicker/IconPickerConstants.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct IconPickerConstants {
+
+    static let emojis: [String] = [
+        // Faces & Emotions
+        "😀", "😂", "🥹", "😍", "🤩", "😎", "🥳", "😤", "🤯", "🥺",
+        // Hands & People
+        "👋", "👍", "👎", "✌️", "🤞", "💪", "🙏", "🧑‍💻", "🧠", "👀",
+        // Hearts & Symbols
+        "❤️", "🧡", "💛", "💚", "💙", "💜", "🖤", "🤍", "💔", "💯",
+        // Animals
+        "🐶", "🐱", "🐻", "🦊", "🐼", "🐨", "🦁", "🐸", "🐙", "🦋",
+        // Nature & Weather
+        "🌸", "🌺", "🌻", "🌲", "🍀", "🌈", "⚡", "🔥", "❄️", "🌊",
+        // Food & Drink
+        "🍎", "🍕", "🍔", "🌮", "🍣", "🍩", "☕", "🧋", "🍷", "🍺",
+        // Objects
+        "💡", "📱", "💻", "🎧", "📷", "🔑", "💎", "🧲", "🔔", "📌",
+        // Activities & Travel
+        "🚀", "✈️", "🏠", "🏔️", "⛵", "🎯", "🎮", "🎵", "🎬", "📚",
+        // Symbols & Flags
+        "⭐", "🌟", "✨", "💫", "🏆", "🎉", "🎊", "🏁", "🚩", "🔮",
+    ]
+
+    static let sfSymbols: [String] = [
+        // Communication
+        "envelope.fill", "paperplane.fill", "bubble.left.fill", "phone.fill",
+        "video.fill", "mic.fill", "speaker.wave.2.fill", "bell.fill",
+        // Media
+        "play.fill", "pause.fill", "star.fill", "heart.fill",
+        "bookmark.fill", "tag.fill", "camera.fill", "photo.fill",
+        // Files & Folders
+        "doc.fill", "doc.text.fill", "folder.fill", "archivebox.fill",
+        "tray.fill", "externaldrive.fill", "note.text", "list.bullet",
+        // Tools
+        "wrench.fill", "hammer.fill", "paintbrush.fill", "scissors",
+        "pencil", "eraser.fill", "magnifyingglass", "slider.horizontal.3",
+        // Objects
+        "lightbulb.fill", "key.fill", "lock.fill", "pin.fill",
+        "mappin.and.ellipse", "gift.fill", "cart.fill", "creditcard.fill",
+        // People & Body
+        "person.fill", "person.2.fill", "person.3.fill", "hand.thumbsup.fill",
+        "hand.raised.fill", "eye.fill", "brain.head.profile", "figure.walk",
+        // Nature & Science
+        "leaf.fill", "flame.fill", "drop.fill", "snowflake",
+        "cloud.fill", "sun.max.fill", "moon.fill", "sparkles",
+        // Tech & Devices
+        "desktopcomputer", "laptopcomputer", "iphone", "gamecontroller.fill",
+        "keyboard", "printer.fill", "wifi", "antenna.radiowaves.left.and.right",
+        // Shapes & Symbols
+        "circle.fill", "square.fill", "triangle.fill", "diamond.fill",
+        "hexagon.fill", "shield.fill", "flag.fill", "rosette",
+        // Arrows & Actions
+        "arrow.right", "arrow.up.right", "bolt.fill", "power",
+        "checkmark.circle.fill", "xmark.circle.fill", "plus.circle.fill", "minus.circle.fill",
+        // Transportation
+        "car.fill", "airplane", "bus.fill", "bicycle",
+        // Charts & Data
+        "chart.bar.fill", "chart.pie.fill", "chart.line.uptrend.xyaxis", "gauge.medium",
+    ]
+}

--- a/Sources/ArcmarkCore/Components/IconPicker/IconPickerGridView.swift
+++ b/Sources/ArcmarkCore/Components/IconPicker/IconPickerGridView.swift
@@ -1,0 +1,91 @@
+import AppKit
+
+@MainActor
+final class IconPickerGridView: NSView {
+
+    private let scrollView = NSScrollView()
+    private let contentView = FlippedContentView()
+
+    private let cellSize: CGFloat = 34
+    private let cellSpacing: CGFloat = 4
+    private let columns = 8
+
+    private var itemViews: [IconPickerItemView] = []
+
+    var onItemSelected: ((Int) -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.scrollerStyle = .overlay
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = contentView
+
+        addSubview(scrollView)
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    func setItems(_ items: [IconPickerItemView.Content], selectionHandler: @escaping (Int) -> Void) {
+        for view in itemViews {
+            view.removeFromSuperview()
+        }
+        itemViews.removeAll()
+        onItemSelected = selectionHandler
+
+        for (index, content) in items.enumerated() {
+            let itemView = IconPickerItemView(frame: .zero)
+            itemView.configure(content: content)
+            itemView.onItemSelected = { [weak self] in
+                self?.onItemSelected?(index)
+            }
+            contentView.addSubview(itemView)
+            itemViews.append(itemView)
+        }
+
+        layoutGrid()
+    }
+
+    override func layout() {
+        super.layout()
+        layoutGrid()
+    }
+
+    private func layoutGrid() {
+        let totalWidth = bounds.width
+        let availableWidth = totalWidth - CGFloat(columns - 1) * cellSpacing
+        let actualCellSize = max(cellSize, floor(availableWidth / CGFloat(columns)))
+
+        let rows = (itemViews.count + columns - 1) / columns
+        let contentHeight = CGFloat(rows) * actualCellSize + CGFloat(max(0, rows - 1)) * cellSpacing
+
+        contentView.frame = NSRect(x: 0, y: 0, width: totalWidth, height: contentHeight)
+
+        for (index, view) in itemViews.enumerated() {
+            let col = index % columns
+            let row = index / columns
+            let x = CGFloat(col) * (actualCellSize + cellSpacing)
+            let y = CGFloat(row) * (actualCellSize + cellSpacing)
+            view.frame = NSRect(x: x, y: y, width: actualCellSize, height: actualCellSize)
+        }
+    }
+}

--- a/Sources/ArcmarkCore/Components/IconPicker/IconPickerItemView.swift
+++ b/Sources/ArcmarkCore/Components/IconPicker/IconPickerItemView.swift
@@ -1,0 +1,94 @@
+import AppKit
+
+@MainActor
+final class IconPickerItemView: BaseControl {
+
+    private let label = NSTextField(labelWithString: "")
+    private let imageView = NSImageView()
+
+    enum Content {
+        case emoji(String)
+        case sfSymbol(String)
+        case favicon(NSImage)
+    }
+
+    var onItemSelected: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        layer?.cornerRadius = ThemeConstants.CornerRadius.small
+
+        label.alignment = .center
+        label.font = NSFont.systemFont(ofSize: 20)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.isHidden = true
+        addSubview(label)
+
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.isHidden = true
+        addSubview(imageView)
+
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: centerXAnchor),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+
+            imageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            imageView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 20),
+            imageView.heightAnchor.constraint(equalToConstant: 20),
+        ])
+    }
+
+    func configure(content: Content) {
+        label.isHidden = true
+        imageView.isHidden = true
+
+        switch content {
+        case .emoji(let emoji):
+            label.stringValue = emoji
+            label.isHidden = false
+        case .sfSymbol(let name):
+            let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .medium)
+            let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+                .withSymbolConfiguration(config)
+            image?.isTemplate = true
+            imageView.image = image
+            imageView.contentTintColor = ThemeConstants.Colors.darkGray
+                .withAlphaComponent(ThemeConstants.Opacity.high)
+            imageView.isHidden = false
+        case .favicon(let image):
+            image.isTemplate = false
+            imageView.image = image
+            imageView.contentTintColor = nil
+            imageView.isHidden = false
+        }
+    }
+
+    override func handleHoverStateChanged() {
+        layer?.backgroundColor = isHovered
+            ? ThemeConstants.Colors.darkGray.withAlphaComponent(ThemeConstants.Opacity.minimal).cgColor
+            : NSColor.clear.cgColor
+    }
+
+    override func handlePressedStateChanged() {
+        layer?.backgroundColor = isPressed
+            ? ThemeConstants.Colors.darkGray.withAlphaComponent(ThemeConstants.Opacity.subtle).cgColor
+            : isHovered
+                ? ThemeConstants.Colors.darkGray.withAlphaComponent(ThemeConstants.Opacity.minimal).cgColor
+                : NSColor.clear.cgColor
+    }
+
+    override func performAction() {
+        onItemSelected?()
+    }
+}

--- a/Sources/ArcmarkCore/Components/IconPicker/IconPickerPopoverController.swift
+++ b/Sources/ArcmarkCore/Components/IconPicker/IconPickerPopoverController.swift
@@ -1,0 +1,222 @@
+import AppKit
+
+@MainActor
+final class IconPickerPopoverController: NSViewController, NSSearchFieldDelegate {
+
+    private let segmentedControl = NSSegmentedControl()
+    private let searchField = NSSearchField()
+    private let gridView = IconPickerGridView()
+    private let restoreButton = NSButton()
+    private var gridTopToSegmentConstraint: NSLayoutConstraint!
+    private var gridTopToSearchConstraint: NSLayoutConstraint!
+
+    var showRestoreButton: Bool = false
+    var onIconSelected: ((CustomIcon) -> Void)?
+    var onRestoreFavicon: (() -> Void)?
+    var onFaviconPathSelected: ((String) -> Void)?
+
+    private var cachedFavicons: [(path: String, hostname: String, image: NSImage)] = []
+    private var filteredFavicons: [(path: String, hostname: String, image: NSImage)] = []
+
+    override func loadView() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 280, height: 320))
+        container.wantsLayer = true
+        self.view = container
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupSegmentedControl()
+        setupSearchField()
+        setupGridView()
+        setupRestoreButton()
+        loadCachedFavicons()
+        showTab(0)
+    }
+
+    private func setupSegmentedControl() {
+        segmentedControl.segmentCount = 3
+        segmentedControl.setLabel("Emoji", forSegment: 0)
+        segmentedControl.setLabel("Icon", forSegment: 1)
+        segmentedControl.setLabel("Favicon", forSegment: 2)
+        segmentedControl.selectedSegment = 0
+        segmentedControl.segmentStyle = .texturedRounded
+        segmentedControl.target = self
+        segmentedControl.action = #selector(segmentChanged(_:))
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(segmentedControl)
+
+        NSLayoutConstraint.activate([
+            segmentedControl.topAnchor.constraint(equalTo: view.topAnchor, constant: ThemeConstants.Spacing.medium),
+            segmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: ThemeConstants.Spacing.medium),
+            segmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -ThemeConstants.Spacing.medium),
+        ])
+    }
+
+    private func setupSearchField() {
+        searchField.placeholderString = "Search favicons…"
+        searchField.translatesAutoresizingMaskIntoConstraints = false
+        searchField.delegate = self
+        searchField.sendsSearchStringImmediately = true
+        searchField.isHidden = true
+
+        view.addSubview(searchField)
+
+        NSLayoutConstraint.activate([
+            searchField.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: ThemeConstants.Spacing.medium),
+            searchField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: ThemeConstants.Spacing.medium),
+            searchField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -ThemeConstants.Spacing.medium),
+        ])
+    }
+
+    private func setupGridView() {
+        gridView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(gridView)
+
+        gridTopToSegmentConstraint = gridView.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor, constant: ThemeConstants.Spacing.medium)
+        gridTopToSearchConstraint = gridView.topAnchor.constraint(equalTo: searchField.bottomAnchor, constant: ThemeConstants.Spacing.medium)
+
+        NSLayoutConstraint.activate([
+            gridTopToSegmentConstraint,
+            gridView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: ThemeConstants.Spacing.medium),
+            gridView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -ThemeConstants.Spacing.medium),
+        ])
+    }
+
+    private func setupRestoreButton() {
+        restoreButton.title = "Restore"
+        restoreButton.bezelStyle = .rounded
+        restoreButton.target = self
+        restoreButton.action = #selector(restoreTapped)
+        restoreButton.translatesAutoresizingMaskIntoConstraints = false
+        restoreButton.isHidden = !showRestoreButton
+
+        view.addSubview(restoreButton)
+
+        NSLayoutConstraint.activate([
+            restoreButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            restoreButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -ThemeConstants.Spacing.medium),
+        ])
+
+        updateGridBottomConstraint()
+    }
+
+    private func updateGridBottomConstraint() {
+        restoreButton.isHidden = !showRestoreButton
+
+        for constraint in view.constraints where constraint.firstItem === gridView && constraint.firstAttribute == .bottom {
+            constraint.isActive = false
+        }
+
+        if showRestoreButton {
+            gridView.bottomAnchor.constraint(equalTo: restoreButton.topAnchor, constant: -ThemeConstants.Spacing.medium).isActive = true
+        } else {
+            gridView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -ThemeConstants.Spacing.medium).isActive = true
+        }
+    }
+
+    private func setSearchFieldVisible(_ visible: Bool) {
+        searchField.isHidden = !visible
+        gridTopToSegmentConstraint.isActive = !visible
+        gridTopToSearchConstraint.isActive = visible
+        if !visible {
+            searchField.stringValue = ""
+        }
+    }
+
+    private func loadCachedFavicons() {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let iconsDir = appSupport.appendingPathComponent("Arcmark/Icons", isDirectory: true)
+
+        guard FileManager.default.fileExists(atPath: iconsDir.path) else { return }
+        guard let files = try? FileManager.default.contentsOfDirectory(at: iconsDir, includingPropertiesForKeys: nil) else { return }
+
+        for file in files {
+            guard file.pathExtension == "ico" || file.pathExtension == "png" else { continue }
+            if let image = NSImage(contentsOf: file) {
+                let hostname = file.deletingPathExtension().lastPathComponent
+                    .replacingOccurrences(of: "_", with: ":")
+                cachedFavicons.append((path: file.path, hostname: hostname, image: image))
+            }
+        }
+
+        cachedFavicons.sort { $0.hostname.localizedCaseInsensitiveCompare($1.hostname) == .orderedAscending }
+        filteredFavicons = cachedFavicons
+    }
+
+    @objc private func segmentChanged(_ sender: NSSegmentedControl) {
+        showTab(sender.selectedSegment)
+    }
+
+    private func showTab(_ index: Int) {
+        switch index {
+        case 0:
+            setSearchFieldVisible(false)
+            showEmojiTab()
+        case 1:
+            setSearchFieldVisible(false)
+            showSFSymbolTab()
+        case 2:
+            setSearchFieldVisible(true)
+            filterAndShowFavicons()
+        default:
+            break
+        }
+    }
+
+    private func showEmojiTab() {
+        let items = IconPickerConstants.emojis.map { IconPickerItemView.Content.emoji($0) }
+        gridView.setItems(items) { [weak self] index in
+            let emoji = IconPickerConstants.emojis[index]
+            self?.onIconSelected?(.emoji(emoji))
+            self?.dismissPopover()
+        }
+    }
+
+    private func showSFSymbolTab() {
+        let items = IconPickerConstants.sfSymbols.map { IconPickerItemView.Content.sfSymbol($0) }
+        gridView.setItems(items) { [weak self] index in
+            let symbol = IconPickerConstants.sfSymbols[index]
+            self?.onIconSelected?(.sfSymbol(symbol))
+            self?.dismissPopover()
+        }
+    }
+
+    private func filterAndShowFavicons() {
+        let query = searchField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if query.isEmpty {
+            filteredFavicons = cachedFavicons
+        } else {
+            filteredFavicons = cachedFavicons.filter { $0.hostname.lowercased().contains(query) }
+        }
+
+        let items = filteredFavicons.map { IconPickerItemView.Content.favicon($0.image) }
+        gridView.setItems(items) { [weak self] index in
+            guard let self, index < self.filteredFavicons.count else { return }
+            let path = self.filteredFavicons[index].path
+            self.onFaviconPathSelected?(path)
+            self.dismissPopover()
+        }
+    }
+
+    // MARK: - NSSearchFieldDelegate
+
+    func controlTextDidChange(_ obj: Notification) {
+        guard segmentedControl.selectedSegment == 2 else { return }
+        filterAndShowFavicons()
+    }
+
+    @objc private func restoreTapped() {
+        onRestoreFavicon?()
+        dismissPopover()
+    }
+
+    private func dismissPopover() {
+        if let popover = view.window?.parent?.contentViewController?.presentedViewControllers?.first(where: { $0 === self }) {
+            popover.dismiss(nil)
+        } else {
+            view.window?.close()
+        }
+    }
+}

--- a/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabTileView.swift
+++ b/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabTileView.swift
@@ -66,6 +66,14 @@ final class PinnedTabTileView: BaseControl {
                     image.isTemplate = false
                     faviconView.image = image
                     faviconView.contentTintColor = nil
+                } else {
+                    let config = NSImage.SymbolConfiguration(pointSize: ThemeConstants.Sizing.iconLarge, weight: .semibold)
+                    let globe = NSImage(systemSymbolName: "globe", accessibilityDescription: nil)?
+                        .withSymbolConfiguration(config)
+                    globe?.isTemplate = true
+                    faviconView.image = globe
+                    faviconView.contentTintColor = ThemeConstants.Colors.darkGray
+                        .withAlphaComponent(ThemeConstants.Opacity.low)
                 }
             }
         } else if let path = link.faviconPath,

--- a/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabTileView.swift
+++ b/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabTileView.swift
@@ -46,7 +46,29 @@ final class PinnedTabTileView: BaseControl {
         linkId = link.id
         linkURL = link.url
 
-        if let path = link.faviconPath,
+        if let customIcon = link.customIcon {
+            switch customIcon {
+            case .emoji(let emoji):
+                let image = NodeListViewController.imageFromEmoji(emoji, size: ThemeConstants.Sizing.iconLarge)
+                faviconView.image = image
+                faviconView.contentTintColor = nil
+            case .sfSymbol(let name):
+                let config = NSImage.SymbolConfiguration(pointSize: ThemeConstants.Sizing.iconLarge, weight: .semibold)
+                let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+                    .withSymbolConfiguration(config)
+                image?.isTemplate = true
+                faviconView.image = image
+                faviconView.contentTintColor = ThemeConstants.Colors.darkGray
+                    .withAlphaComponent(ThemeConstants.Opacity.high)
+            case .cachedFavicon(let path):
+                if FileManager.default.fileExists(atPath: path),
+                   let image = NSImage(contentsOfFile: path) {
+                    image.isTemplate = false
+                    faviconView.image = image
+                    faviconView.contentTintColor = nil
+                }
+            }
+        } else if let path = link.faviconPath,
            FileManager.default.fileExists(atPath: path),
            let image = NSImage(contentsOfFile: path) {
             image.isTemplate = false

--- a/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabsView.swift
+++ b/Sources/ArcmarkCore/Components/PinnedTabs/PinnedTabsView.swift
@@ -94,6 +94,10 @@ final class PinnedTabsView: NSView {
         return NSSize(width: NSView.noIntrinsicMetric, height: height)
     }
 
+    func tileView(for linkId: UUID) -> PinnedTabTileView? {
+        tileViews.first(where: { $0.linkId == linkId })
+    }
+
     private func fetchFaviconIfNeeded(for link: Link) {
         guard link.faviconPath == nil || !FileManager.default.fileExists(atPath: link.faviconPath ?? "") else { return }
         guard let url = URL(string: link.url) else { return }

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -343,6 +343,11 @@ final class MainViewController: NSViewController {
         nodeListViewController.canPinLink = { [weak self] in
             self?.model.canPinMore ?? false
         }
+
+        nodeListViewController.onChangeIconRequested = { [weak self] nodeId, anchorView in
+            guard let self, let node = self.model.nodeById(nodeId), case .link(let link) = node else { return }
+            self.showIconPicker(for: nodeId, relativeTo: anchorView, hasCustomIcon: link.customIcon != nil, isPinned: false)
+        }
     }
 
     private func bindModel() {
@@ -767,12 +772,69 @@ final class MainViewController: NSViewController {
         unpinItem.target = self
         unpinItem.representedObject = linkId
         menu.addItem(unpinItem)
+
+        menu.addItem(NSMenuItem.separator())
+
+        let changeIcon = NSMenuItem(title: "Change Icon…", action: #selector(changePinnedTabIcon(_:)), keyEquivalent: "")
+        changeIcon.target = self
+        changeIcon.representedObject = linkId
+        menu.addItem(changeIcon)
+
         NSMenu.popUpContextMenu(menu, with: event, for: pinnedTabsView)
     }
 
     @objc private func unpinTab(_ sender: NSMenuItem) {
         guard let linkId = sender.representedObject as? UUID else { return }
         model.unpinLink(id: linkId)
+    }
+
+    @objc private func changePinnedTabIcon(_ sender: NSMenuItem) {
+        guard let linkId = sender.representedObject as? UUID,
+              let link = model.pinnedLinkById(linkId) else { return }
+        // Find the tile view for this pinned link
+        let anchorView = pinnedTabsView.tileView(for: linkId) ?? pinnedTabsView
+        showIconPicker(for: linkId, relativeTo: anchorView, hasCustomIcon: link.customIcon != nil, isPinned: true)
+    }
+
+    private func showIconPicker(for linkId: UUID, relativeTo anchorView: NSView, hasCustomIcon: Bool, isPinned: Bool) {
+        let popover = NSPopover()
+        let pickerController = IconPickerPopoverController()
+        pickerController.showRestoreButton = hasCustomIcon
+
+        pickerController.onIconSelected = { [weak self, weak popover] icon in
+            guard let self else { return }
+            if isPinned {
+                self.model.setPinnedLinkCustomIcon(id: linkId, icon: icon)
+            } else {
+                self.model.setLinkCustomIcon(id: linkId, icon: icon)
+            }
+            popover?.close()
+        }
+
+        pickerController.onRestoreFavicon = { [weak self, weak popover] in
+            guard let self else { return }
+            if isPinned {
+                self.model.setPinnedLinkCustomIcon(id: linkId, icon: nil)
+            } else {
+                self.model.setLinkCustomIcon(id: linkId, icon: nil)
+            }
+            popover?.close()
+        }
+
+        pickerController.onFaviconPathSelected = { [weak self, weak popover] path in
+            guard let self else { return }
+            if isPinned {
+                self.model.setPinnedLinkCustomIcon(id: linkId, icon: .cachedFavicon(path))
+            } else {
+                self.model.setLinkCustomIcon(id: linkId, icon: .cachedFavicon(path))
+            }
+            popover?.close()
+        }
+
+        popover.contentViewController = pickerController
+        popover.contentSize = NSSize(width: 280, height: 320)
+        popover.behavior = .transient
+        popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .minY)
     }
 
     // MARK: - Bulk Operations

--- a/Sources/ArcmarkCore/Models.swift
+++ b/Sources/ArcmarkCore/Models.swift
@@ -77,11 +77,58 @@ struct Workspace: Codable, Identifiable, Equatable {
     }
 }
 
+enum CustomIcon: Codable, Equatable, Sendable {
+    case emoji(String)
+    case sfSymbol(String)
+    case cachedFavicon(String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case value
+    }
+
+    private enum IconType: String, Codable {
+        case emoji
+        case sfSymbol
+        case cachedFavicon
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(IconType.self, forKey: .type)
+        let value = try container.decode(String.self, forKey: .value)
+        switch type {
+        case .emoji:
+            self = .emoji(value)
+        case .sfSymbol:
+            self = .sfSymbol(value)
+        case .cachedFavicon:
+            self = .cachedFavicon(value)
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .emoji(let value):
+            try container.encode(IconType.emoji, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .sfSymbol(let value):
+            try container.encode(IconType.sfSymbol, forKey: .type)
+            try container.encode(value, forKey: .value)
+        case .cachedFavicon(let value):
+            try container.encode(IconType.cachedFavicon, forKey: .type)
+            try container.encode(value, forKey: .value)
+        }
+    }
+}
+
 struct Link: Codable, Identifiable, Equatable, Sendable {
     var id: UUID
     var title: String
     var url: String
     var faviconPath: String?
+    var customIcon: CustomIcon?
 }
 
 struct Folder: Codable, Identifiable, Equatable, Sendable {

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -53,6 +53,7 @@ final class NodeListViewController: NSViewController {
     var onBulkOpenLinks: (([UUID]) -> Void)?
     var onPinLink: ((UUID) -> Void)?
     var canPinLink: (() -> Bool)?
+    var onChangeIconRequested: ((UUID, NSView) -> Void)?
 
     // Data provider closure
     var nodeProvider: (() -> [Node])?
@@ -536,6 +537,26 @@ final class NodeListViewController: NSViewController {
     }
 }
 
+// MARK: - Emoji Helper
+
+extension NodeListViewController {
+    static func imageFromEmoji(_ emoji: String, size: CGFloat) -> NSImage {
+        let image = NSImage(size: NSSize(width: size, height: size))
+        image.lockFocus()
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: size * 0.85)
+        ]
+        let string = NSAttributedString(string: emoji, attributes: attributes)
+        let stringSize = string.size()
+        let x = (size - stringSize.width) / 2
+        let y = (size - stringSize.height) / 2
+        string.draw(at: NSPoint(x: x, y: y))
+        image.unlockFocus()
+        image.isTemplate = false
+        return image
+    }
+}
+
 // MARK: - NSCollectionViewDataSource
 
 extension NodeListViewController: NSCollectionViewDataSource {
@@ -569,17 +590,38 @@ extension NodeListViewController: NSCollectionViewDataSource {
                 isSelected: isSelected
             )
         case .link(let link):
-            let globeIconConfig = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
-            let placeholder = NSImage(systemSymbolName: "globe", accessibilityDescription: nil)?.withSymbolConfiguration(globeIconConfig)
-            placeholder?.isTemplate = true
-            var iconToUse = placeholder
+            var iconToUse: NSImage?
             var shouldFetch = true
-            if let path = link.faviconPath,
+
+            if let customIcon = link.customIcon {
+                shouldFetch = false
+                switch customIcon {
+                case .emoji(let emoji):
+                    iconToUse = Self.imageFromEmoji(emoji, size: 20)
+                case .sfSymbol(let name):
+                    let config = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+                    let image = NSImage(systemSymbolName: name, accessibilityDescription: nil)?
+                        .withSymbolConfiguration(config)
+                    image?.isTemplate = true
+                    iconToUse = image
+                case .cachedFavicon(let path):
+                    if FileManager.default.fileExists(atPath: path),
+                       let image = NSImage(contentsOfFile: path) {
+                        image.isTemplate = false
+                        iconToUse = image
+                    }
+                }
+            } else if let path = link.faviconPath,
                FileManager.default.fileExists(atPath: path),
                let image = NSImage(contentsOfFile: path) {
                 image.isTemplate = false
                 iconToUse = image
                 shouldFetch = false
+            } else {
+                let globeIconConfig = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+                let placeholder = NSImage(systemSymbolName: "globe", accessibilityDescription: nil)?.withSymbolConfiguration(globeIconConfig)
+                placeholder?.isTemplate = true
+                iconToUse = placeholder
             }
 
             nodeItem.configure(
@@ -855,6 +897,13 @@ extension NodeListViewController: NSMenuDelegate {
             editUrl.representedObject = node.id
             menu.addItem(editUrl)
 
+            menu.addItem(NSMenuItem.separator())
+
+            let changeIcon = NSMenuItem(title: "Change Icon…", action: #selector(contextChangeIcon(_:)), keyEquivalent: "")
+            changeIcon.target = self
+            changeIcon.representedObject = node.id
+            menu.addItem(changeIcon)
+
             let moveMenu = NSMenuItem(title: "Move to", action: nil, keyEquivalent: "")
             let submenu = NSMenu()
             if let workspaces = workspacesProvider?(), let currentId = currentWorkspaceIdProvider?() {
@@ -939,6 +988,13 @@ extension NodeListViewController: NSMenuDelegate {
     @objc private func contextPinLink(_ sender: NSMenuItem) {
         guard let nodeId = sender.representedObject as? UUID else { return }
         onPinLink?(nodeId)
+    }
+
+    @objc private func contextChangeIcon(_ sender: NSMenuItem) {
+        guard let nodeId = sender.representedObject as? UUID,
+              let indexPath = contextIndexPath,
+              let item = collectionView.item(at: indexPath) else { return }
+        onChangeIconRequested?(nodeId, item.view)
     }
 
     private func populateBulkContextMenu(_ menu: NSMenu) {

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -609,6 +609,11 @@ extension NodeListViewController: NSCollectionViewDataSource {
                        let image = NSImage(contentsOfFile: path) {
                         image.isTemplate = false
                         iconToUse = image
+                    } else {
+                        let globeConfig = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+                        let placeholder = NSImage(systemSymbolName: "globe", accessibilityDescription: nil)?.withSymbolConfiguration(globeConfig)
+                        placeholder?.isTemplate = true
+                        iconToUse = placeholder
                     }
                 }
             } else if let path = link.faviconPath,

--- a/Tests/ArcmarkTests/ModelTests.swift
+++ b/Tests/ArcmarkTests/ModelTests.swift
@@ -624,6 +624,83 @@ final class ModelTests: XCTestCase {
         XCTAssertEqual(Set(collectedLinks.map(\.url)), Set(["https://root.com", "https://nested.com"]))
     }
 
+    // MARK: - Custom Icon Tests
+
+    func testCustomIconJSONRoundTrip() throws {
+        let link = Link(id: UUID(), title: "Test", url: "https://test.com", faviconPath: nil, customIcon: .emoji("🔥"))
+        let data = try JSONEncoder().encode(link)
+        let decoded = try JSONDecoder().decode(Link.self, from: data)
+        XCTAssertEqual(decoded.customIcon, .emoji("🔥"))
+    }
+
+    func testCustomIconSFSymbolRoundTrip() throws {
+        let link = Link(id: UUID(), title: "Test", url: "https://test.com", faviconPath: nil, customIcon: .sfSymbol("star.fill"))
+        let data = try JSONEncoder().encode(link)
+        let decoded = try JSONDecoder().decode(Link.self, from: data)
+        XCTAssertEqual(decoded.customIcon, .sfSymbol("star.fill"))
+    }
+
+    func testCustomIconNilRoundTrip() throws {
+        let link = Link(id: UUID(), title: "Test", url: "https://test.com", faviconPath: nil)
+        let data = try JSONEncoder().encode(link)
+        let decoded = try JSONDecoder().decode(Link.self, from: data)
+        XCTAssertNil(decoded.customIcon)
+    }
+
+    func testBackwardCompatibilityNoCustomIcon() throws {
+        let json = """
+        {
+            "id": "00000000-0000-0000-0000-000000000001",
+            "title": "Old Link",
+            "url": "https://old.com"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let decoded = try JSONDecoder().decode(Link.self, from: data)
+        XCTAssertEqual(decoded.title, "Old Link")
+        XCTAssertNil(decoded.customIcon)
+        XCTAssertNil(decoded.faviconPath)
+    }
+
+    func testSetLinkCustomIcon() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        let linkId = model.addLink(urlString: "https://a.com", title: "A", parentId: nil)
+
+        // Set emoji custom icon
+        model.setLinkCustomIcon(id: linkId, icon: .emoji("🚀"))
+        if let node = model.nodeById(linkId), case .link(let link) = node {
+            XCTAssertEqual(link.customIcon, .emoji("🚀"))
+        } else {
+            XCTFail("Expected link")
+        }
+
+        // Restore (set to nil)
+        model.setLinkCustomIcon(id: linkId, icon: nil)
+        if let node = model.nodeById(linkId), case .link(let link) = node {
+            XCTAssertNil(link.customIcon)
+        } else {
+            XCTFail("Expected link")
+        }
+    }
+
+    func testSetPinnedLinkCustomIcon() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        let linkId = model.addLink(urlString: "https://a.com", title: "A", parentId: nil)
+        model.pinLink(id: linkId)
+
+        model.setPinnedLinkCustomIcon(id: linkId, icon: .sfSymbol("heart.fill"))
+        XCTAssertEqual(model.currentWorkspace.pinnedLinks[0].customIcon, .sfSymbol("heart.fill"))
+
+        model.setPinnedLinkCustomIcon(id: linkId, icon: nil)
+        XCTAssertNil(model.currentWorkspace.pinnedLinks[0].customIcon)
+    }
+
     func testMultipleBrowserProfiles() {
         let store = makeStore()
         store.save(DataStore.defaultState())


### PR DESCRIPTION
## Summary
- Added `CustomIcon` data model supporting emoji, SF Symbols, and cached favicons
- Implemented icon picker UI with emoji, SF Symbol, and favicon tabs
- Integrated icon picker into context menus for links in the main list
- Custom icons render in both node list and pinned tabs with proper fallbacks
- Added globe icon fallback when cached favicon files are missing
- Added comprehensive tests for CustomIcon JSON serialization

## Test plan
- [ ] Right-click a link and verify icon picker opens in context menu
- [ ] Select emoji/SF Symbol and verify it renders in node list and pinned tabs
- [ ] Delete favicon cache file and verify globe fallback appears
- [ ] Run swift test to verify CustomIcon encoding/decoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)