### PR TITLE
fix: ignore swipe gestures when window is hidden

### DIFF
--- a/Sources/ArcmarkCore/SwipeGestureService.swift
+++ b/Sources/ArcmarkCore/SwipeGestureService.swift
@@ -100,7 +100,7 @@ final class SwipeGestureService {
     }
 
     private func handleBegan(_ event: NSEvent) {
-        guard let window else { return }
+        guard let window, window.isVisible else { return }
 
         let mouseLocation = NSEvent.mouseLocation
         guard window.frame.contains(mouseLocation) else { return }


### PR DESCRIPTION
## Summary
- Guard `SwipeGestureService.handleBegan` on `window.isVisible` so the global scroll-event monitor does not start a swipe against a hidden window (its `frame` is still set, so the existing `frame.contains` check would otherwise pass).

## Test plan
- [ ] Hide the main window, perform a horizontal trackpad swipe, and confirm no swipe gesture is initiated.
- [ ] With the window visible, confirm normal left/right swipe behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)