### PR TITLE
fix: skip orderOut on hidden window during app switch

### DIFF
--- a/Sources/ArcmarkCore/AppDelegate.swift
+++ b/Sources/ArcmarkCore/AppDelegate.swift
@@ -543,7 +543,8 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
     }
 
     func attachmentServiceShouldHideWindow(_ service: WindowAttachmentService) {
-        window?.orderOut(nil)
+        guard let window, window.isVisible else { return }
+        window.orderOut(nil)
     }
 
     func attachmentServiceShouldShowWindow(_ service: WindowAttachmentService) {


### PR DESCRIPTION
## Summary
While Arcmark was hidden via the toggle shortcut (Cmd+Shift+B) in browser-attachment mode, every Cmd+Tab to a non-browser app caused `WindowAttachmentService` to invoke `attachmentServiceShouldHideWindow`, which unconditionally called `orderOut(nil)` on the already-hidden window. That window-server interaction during another app's activation could leave the target app focused but with no key window, requiring an extra click. Guard the delegate so it only calls `orderOut` when the window is actually visible — same pattern as PR #50's `window.isVisible` guard for swipe gestures.

## Test plan
- [ ] In attachment mode with a browser (e.g. Helium), hide Arcmark via Cmd+Shift+B, then Cmd+Tab to another app — its window should be focused immediately, no click required.
- [ ] Cmd+Tab back to the browser; Arcmark stays hidden until Cmd+Shift+B re-shows it.
- [ ] Normal show/hide via Cmd+Shift+B and browser-follow behavior unchanged when window is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)