### PR TITLE
Drop per-launch token auth from note server and add disconnected state

### DIFF
--- a/Sources/ArcmarkCore/NoteEditor/editor.css
+++ b/Sources/ArcmarkCore/NoteEditor/editor.css
@@ -143,13 +143,18 @@ html, body {
   margin: 0;
 }
 
-body.note-deleted .tabs {
+body.note-deleted .tabs,
+body.server-disconnected .tabs {
   visibility: hidden;
 }
 
 body.note-deleted .note-title {
   opacity: 0.5;
   text-decoration: line-through;
+}
+
+body.server-disconnected .note-title {
+  opacity: 0.5;
 }
 
 .editor {

--- a/Sources/ArcmarkCore/NoteEditor/editor.js
+++ b/Sources/ArcmarkCore/NoteEditor/editor.js
@@ -17,6 +17,7 @@
   let savedTickerTimer = null;
   let serverTitle = "";
   let noteDeleted = false;
+  let serverDisconnected = false;
 
   // Reads/writes against the contenteditable node go through these two
   // helpers so future iterations can layer syntax-aware visual styling
@@ -98,6 +99,34 @@
     document.title = "Deleted note — Arcmark";
   }
 
+  function enterDisconnectedState() {
+    if (serverDisconnected) return;
+    serverDisconnected = true;
+    stopSavedTicker();
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    document.body.classList.add("server-disconnected");
+    editor.setAttribute("contenteditable", "false");
+
+    const main = document.querySelector("main.content");
+    if (main) {
+      main.innerHTML = "";
+      const card = document.createElement("div");
+      card.className = "empty-state";
+      const heading = document.createElement("h2");
+      heading.textContent = "Editor disconnected";
+      const blurb = document.createElement("p");
+      blurb.textContent = "Arcmark restarted, so this tab can no longer reach the editor. Reopen this note from Arcmark to continue editing.";
+      card.appendChild(heading);
+      card.appendChild(blurb);
+      main.appendChild(card);
+    }
+    setStatus("disconnected");
+    document.title = "Disconnected — Arcmark";
+  }
+
   async function loadNote() {
     if (!noteId) {
       setStatus("missing note id");
@@ -123,12 +152,12 @@
       setStatus("saved");
       scheduleSavedTicker();
     } catch (err) {
-      setStatus("load failed");
+      enterDisconnectedState();
     }
   }
 
   async function saveNote() {
-    if (!noteId || noteDeleted) return;
+    if (!noteId || noteDeleted || serverDisconnected) return;
     setStatus("saving…");
     try {
       const response = await fetch(`/api/notes/${noteId}`, {
@@ -150,13 +179,12 @@
       setStatus("saved");
       scheduleSavedTicker();
     } catch (err) {
-      stopSavedTicker();
-      setStatus("save failed");
+      enterDisconnectedState();
     }
   }
 
   function scheduleSave() {
-    if (noteDeleted) return;
+    if (noteDeleted || serverDisconnected) return;
     if (saveTimer) clearTimeout(saveTimer);
     setStatus("editing…");
     saveTimer = setTimeout(saveNote, 500);

--- a/Sources/ArcmarkCore/NoteEditor/editor.js
+++ b/Sources/ArcmarkCore/NoteEditor/editor.js
@@ -3,7 +3,6 @@
 
   const params = new URLSearchParams(window.location.search);
   const noteId = params.get("id");
-  const token = params.get("token");
 
   const editor = document.getElementById("editor");
   const previewPane = document.getElementById("pane-preview");
@@ -99,24 +98,13 @@
     document.title = "Deleted note — Arcmark";
   }
 
-  function authHeaders(extra) {
-    const headers = Object.assign({ "X-Arcmark-Token": token }, extra || {});
-    return headers;
-  }
-
-  function authedUrl(path) {
-    const sep = path.includes("?") ? "&" : "?";
-    return `${path}${sep}token=${encodeURIComponent(token)}`;
-  }
-
   async function loadNote() {
     if (!noteId) {
       setStatus("missing note id");
       return;
     }
     try {
-      const response = await fetch(authedUrl(`/api/notes/${noteId}`), {
-        headers: authHeaders(),
+      const response = await fetch(`/api/notes/${noteId}`, {
         cache: "no-store"
       });
       if (response.status === 404) {
@@ -143,9 +131,9 @@
     if (!noteId || noteDeleted) return;
     setStatus("saving…");
     try {
-      const response = await fetch(authedUrl(`/api/notes/${noteId}`), {
+      const response = await fetch(`/api/notes/${noteId}`, {
         method: "PUT",
-        headers: authHeaders({ "Content-Type": "application/json" }),
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ content: getContent() }),
         cache: "no-store"
       });

--- a/Sources/ArcmarkCore/NoteEditor/index.html
+++ b/Sources/ArcmarkCore/NoteEditor/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="referrer" content="no-referrer">
   <title>Arcmark Note</title>
-  <link rel="stylesheet" href="/editor/editor.css?token={{TOKEN}}">
+  <link rel="stylesheet" href="/editor/editor.css">
 </head>
 <body>
   <header class="topbar">
@@ -30,8 +30,8 @@
     </div>
     <div id="pane-preview" class="pane preview-pane" role="tabpanel" aria-labelledby="tab-preview" hidden></div>
   </main>
-  <script src="/editor/vendor/marked.min.js?token={{TOKEN}}"></script>
-  <script src="/editor/vendor/purify.min.js?token={{TOKEN}}"></script>
-  <script src="/editor/editor.js?token={{TOKEN}}"></script>
+  <script src="/editor/vendor/marked.min.js"></script>
+  <script src="/editor/vendor/purify.min.js"></script>
+  <script src="/editor/editor.js"></script>
 </body>
 </html>

--- a/Sources/ArcmarkCore/Notes/NoteServer.swift
+++ b/Sources/ArcmarkCore/Notes/NoteServer.swift
@@ -4,9 +4,8 @@ import os
 
 /// Minimal loopback-only HTTP server that backs the bundled markdown note editor.
 ///
-/// Binds to 127.0.0.1 on a system-assigned ephemeral port, authenticates every
-/// request with a 256-bit random token, and rejects requests whose Host header
-/// doesn't match 127.0.0.1:<port> (DNS rebinding defense).
+/// Binds to 127.0.0.1 on a system-assigned ephemeral port and rejects requests
+/// whose Host header doesn't match 127.0.0.1:<port> (DNS rebinding defense).
 @MainActor
 final class NoteServer {
     private let logger = Logger(subsystem: "com.arcmark.app", category: "noteserver")
@@ -16,23 +15,11 @@ final class NoteServer {
 
     private var listener: NWListener?
     private(set) var port: UInt16 = 0
-    let token: String
 
     init(model: AppModel, resourcesURL: URL? = Bundle.module.resourceURL) {
         self.model = model
         self.noteStorage = model.noteStorage
         self.resourcesURL = resourcesURL
-        self.token = Self.generateToken()
-    }
-
-    private static func generateToken() -> String {
-        var bytes = [UInt8](repeating: 0, count: 32)
-        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
-        let data = Data(bytes)
-        return data.base64EncodedString()
-            .replacingOccurrences(of: "+", with: "-")
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: "=", with: "")
     }
 
     func start() {
@@ -81,7 +68,7 @@ final class NoteServer {
 
     func editorURL(noteId: UUID) -> URL? {
         guard port > 0 else { return nil }
-        return URL(string: "http://127.0.0.1:\(port)/?id=\(noteId.uuidString)&token=\(token)")
+        return URL(string: "http://127.0.0.1:\(port)/?id=\(noteId.uuidString)")
     }
 
     // MARK: - Connection handling
@@ -190,17 +177,8 @@ final class NoteServer {
             return
         }
 
-        // Browsers fetch /favicon.ico automatically with no token; serve a
-        // 204 so we don't log noisy 401s.
         if request.method == "GET" && request.path == "/favicon.ico" {
             sendResponse(status: 204, statusMessage: "No Content", contentType: "image/x-icon", body: Data(), on: connection)
-            return
-        }
-
-        // Token check (applies to all routes — including static assets)
-        let providedToken = request.query["token"] ?? request.headers["x-arcmark-token"] ?? ""
-        if !constantTimeEqual(providedToken, token) {
-            sendStatus(401, message: "Unauthorized", on: connection)
             return
         }
 
@@ -278,11 +256,10 @@ final class NoteServer {
         let assetURL = resourcesURL
             .appendingPathComponent("NoteEditor", isDirectory: true)
             .appendingPathComponent("index.html")
-        guard var html = try? String(contentsOf: assetURL, encoding: .utf8) else {
+        guard let html = try? String(contentsOf: assetURL, encoding: .utf8) else {
             sendStatus(404, message: "Asset Missing", on: connection)
             return
         }
-        html = html.replacingOccurrences(of: "{{TOKEN}}", with: token)
         sendResponse(status: 200, statusMessage: "OK", contentType: "text/html; charset=utf-8", body: Data(html.utf8), on: connection)
     }
 
@@ -368,14 +345,4 @@ final class NoteServer {
         })
     }
 
-    private func constantTimeEqual(_ a: String, _ b: String) -> Bool {
-        let lhs = Array(a.utf8)
-        let rhs = Array(b.utf8)
-        if lhs.count != rhs.count { return false }
-        var result: UInt8 = 0
-        for i in 0..<lhs.count {
-            result |= lhs[i] ^ rhs[i]
-        }
-        return result == 0
-    }
 }

--- a/Tests/ArcmarkTests/NoteServerTests.swift
+++ b/Tests/ArcmarkTests/NoteServerTests.swift
@@ -51,25 +51,16 @@ final class NoteServerTests: XCTestCase {
         let (server, _) = try await startServer()
         defer { server.stop() }
         XCTAssertGreaterThan(server.port, 0)
-        XCTAssertFalse(server.token.isEmpty)
     }
 
-    func testGetWithoutTokenIsUnauthorized() async throws {
-        let (server, _) = try await startServer()
-        defer { server.stop() }
-        let id = UUID()
-        let (status, _) = try await request(method: "GET", path: "/api/notes/\(id.uuidString)", port: server.port)
-        XCTAssertEqual(status, 401)
-    }
-
-    func testGetWithTokenReturnsNoteJSON() async throws {
+    func testGetReturnsNoteJSON() async throws {
         let (server, model) = try await startServer()
         defer { server.stop() }
         let noteId = model.addNote(title: "Server Test", parentId: nil)
 
         let (status, body) = try await request(
             method: "GET",
-            path: "/api/notes/\(noteId.uuidString)?token=\(server.token)",
+            path: "/api/notes/\(noteId.uuidString)",
             port: server.port
         )
         XCTAssertEqual(status, 200)
@@ -86,7 +77,7 @@ final class NoteServerTests: XCTestCase {
 
         let (status, _) = try await request(
             method: "GET",
-            path: "/api/notes/\(noteId.uuidString)?token=\(server.token)",
+            path: "/api/notes/\(noteId.uuidString)",
             port: server.port
         )
         XCTAssertEqual(status, 404)
@@ -101,7 +92,7 @@ final class NoteServerTests: XCTestCase {
         let body = try JSONSerialization.data(withJSONObject: ["content": "should not write"])
         let (status, _) = try await request(
             method: "PUT",
-            path: "/api/notes/\(noteId.uuidString)?token=\(server.token)",
+            path: "/api/notes/\(noteId.uuidString)",
             body: body,
             port: server.port
         )
@@ -117,7 +108,7 @@ final class NoteServerTests: XCTestCase {
         let body = try JSONSerialization.data(withJSONObject: ["content": "## Updated"])
         let (status, _) = try await request(
             method: "PUT",
-            path: "/api/notes/\(noteId.uuidString)?token=\(server.token)",
+            path: "/api/notes/\(noteId.uuidString)",
             body: body,
             port: server.port
         )


### PR DESCRIPTION
## Summary
- Remove the 256-bit token check from `NoteServer` along with the `{{TOKEN}}` HTML templating and `token=` query/header plumbing in `editor.js`/`index.html`; loopback bind + Host header check remain as the defenses.
- Add a `serverDisconnected` flow in the editor: on a thrown fetch, swap `main.content` for an "Editor disconnected" card, hide tabs via `body.server-disconnected`, dim the title, and stop saves/ticker.
- Update `NoteServerTests` to drop the unauthorized-token case and remove `token=` from request paths.

## Test plan
- [ ] `swift test --filter NoteServerTests`
- [ ] Open a note in Arcmark, restart the app, confirm the open tab shows the disconnected empty state and stops trying to save.