### PR TITLE
feat(notes): show placeholder instead of starter content for new notes

### DIFF
--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -152,16 +152,10 @@ final class AppModel {
     @discardableResult
     func addNote(title: String, parentId: UUID?) -> UUID {
         let note = Note(id: UUID(), title: title, customIcon: nil)
-        try? noteStorage.write(id: note.id, content: Self.starterNoteContent)
+        try? noteStorage.write(id: note.id, content: "")
         insertNode(.note(note), parentId: parentId)
         return note.id
     }
-
-    private static let starterNoteContent = """
-    # Untitled
-
-    Start writing your note here…
-    """
 
     func renameNode(id: UUID, newName: String) {
         updateNode(id: id) { node in

--- a/Sources/ArcmarkCore/NoteEditor/editor.css
+++ b/Sources/ArcmarkCore/NoteEditor/editor.css
@@ -166,6 +166,15 @@ body.server-disconnected .note-title {
   line-height: 1.7;
   min-height: calc(100vh - 120px);
   caret-color: var(--accent);
+  position: relative;
+}
+
+.editor.is-empty::before {
+  content: attr(data-placeholder);
+  color: var(--muted);
+  position: absolute;
+  pointer-events: none;
+  user-select: none;
 }
 
 .preview-pane h1,

--- a/Sources/ArcmarkCore/NoteEditor/editor.js
+++ b/Sources/ArcmarkCore/NoteEditor/editor.js
@@ -28,6 +28,15 @@
 
   function setContent(value) {
     editor.textContent = value;
+    refreshEmptyState();
+  }
+
+  // Browsers may leave a stray <br> or trailing newline inside a
+  // contenteditable after the user deletes all text, so normalize before
+  // deciding whether to show the placeholder.
+  function refreshEmptyState() {
+    const isEmpty = editor.innerText.replace(/\n+$/, "") === "";
+    editor.classList.toggle("is-empty", isEmpty);
   }
 
   function setStatus(text) {
@@ -226,10 +235,12 @@
     range.collapse(false);
     selection.removeAllRanges();
     selection.addRange(range);
+    refreshEmptyState();
     scheduleSave();
   });
 
   editor.addEventListener("input", function () {
+    refreshEmptyState();
     refreshTitle();
     scheduleSave();
   });

--- a/Sources/ArcmarkCore/NoteEditor/index.html
+++ b/Sources/ArcmarkCore/NoteEditor/index.html
@@ -26,7 +26,7 @@
   </header>
   <main class="content">
     <div id="pane-edit" class="pane edit-pane" role="tabpanel" aria-labelledby="tab-edit">
-      <div id="editor" class="editor" contenteditable="plaintext-only" spellcheck="false"></div>
+      <div id="editor" class="editor" contenteditable="plaintext-only" spellcheck="false" data-placeholder="Start writing…"></div>
     </div>
     <div id="pane-preview" class="pane preview-pane" role="tabpanel" aria-labelledby="tab-preview" hidden></div>
   </main>

--- a/Tests/ArcmarkTests/ModelTests.swift
+++ b/Tests/ArcmarkTests/ModelTests.swift
@@ -774,9 +774,9 @@ final class ModelTests: XCTestCase {
             XCTFail("Expected note at root")
         }
 
-        // Starter content should be written to disk
+        // New notes start with empty content; the editor shows a placeholder instead.
         let content = model.noteStorage.read(id: noteId)
-        XCTAssertTrue(content.contains("# Untitled"))
+        XCTAssertEqual(content, "")
     }
 
     func testRenameNote() {


### PR DESCRIPTION
## Summary
- New notes are now created with empty content rather than a hardcoded `# Untitled` starter.
- The editor renders a `Start writing…` placeholder via a CSS `::before` on `.editor.is-empty`, refreshed on load, input, and paste (trailing newlines from contenteditable are normalized so the placeholder reappears after a full deletion).
- Updated `testCreateNote` to assert the new empty-content contract.

## Test plan
- [ ] Create a new note and verify the placeholder is visible until typing begins.
- [ ] Delete all content (including via select-all + backspace) and confirm the placeholder reappears.
- [ ] Paste text into an empty editor and confirm the placeholder disappears.
- [ ] `swift test --filter ModelTests.testCreateNote` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)