### PR TITLE
feat(paste): create note from clipboard text when no URLs found

### DIFF
--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -150,9 +150,9 @@ final class AppModel {
     }
 
     @discardableResult
-    func addNote(title: String, parentId: UUID?) -> UUID {
+    func addNote(title: String, parentId: UUID?, content: String = "") -> UUID {
         let note = Note(id: UUID(), title: title, customIcon: nil)
-        try? noteStorage.write(id: note.id, content: "")
+        try? noteStorage.write(id: note.id, content: content)
         insertNode(.note(note), parentId: parentId)
         return note.id
     }

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -711,11 +711,16 @@ final class MainViewController: NSViewController {
     @objc private func pasteLink() {
         guard let pasted = NSPasteboard.general.string(forType: .string) else { return }
         let urls = extractUrls(from: pasted)
-        guard !urls.isEmpty else { return }
-        for url in urls {
-            let linkId = model.addLink(urlString: url.absoluteString, title: titleForUrl(url), parentId: nil)
-            fetchTitleForNewLink(id: linkId, url: url)
+        if !urls.isEmpty {
+            for url in urls {
+                let linkId = model.addLink(urlString: url.absoluteString, title: titleForUrl(url), parentId: nil)
+                fetchTitleForNewLink(id: linkId, url: url)
+            }
+            return
         }
+        let trimmed = pasted.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        model.addNote(title: "Untitled", parentId: nil, content: trimmed)
     }
 
     private func openLink(_ link: Link) {


### PR DESCRIPTION
## Summary
- When paste detects no URLs in the clipboard, create an "Untitled" note seeded with the trimmed pasted text instead of doing nothing.
- `AppModel.addNote` now accepts an optional `content` parameter (defaults to `""`) so callers can seed initial note content.

## Test plan
- [ ] Copy plain text (no URL) and paste into the app — verify a new "Untitled" note is created with that content.
- [ ] Copy a URL and paste — verify links are still added as before.
- [ ] Copy whitespace-only text and paste — verify nothing is created.