### PR TITLE
feat(scheduler): schedule a link to open at a future time

### DIFF
--- a/Sources/ArcmarkCore/AppDelegate.swift
+++ b/Sources/ArcmarkCore/AppDelegate.swift
@@ -12,6 +12,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
     private var alwaysOnTopMenuItem: NSMenuItem?
     private var updaterController: SPUStandardUpdaterController!
     private var noteServer: NoteServer?
+    private var scheduler: SchedulerService?
 
     // Attachment state
     private var isAttachmentMode: Bool = false
@@ -73,7 +74,52 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
         setupGlobalHotkey()
         setupSwipeGesture()
         observeBrowserChanges()
+        setupScheduler(model: model)
         NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func setupScheduler(model: AppModel) {
+        let scheduler = SchedulerService()
+        self.scheduler = scheduler
+
+        scheduler.onFire = { [weak model] ref in
+            guard let model else { return }
+            if let url = URL(string: ref.url) {
+                let profile = model.state.workspaces
+                    .first(where: { $0.id == ref.workspaceId })?
+                    .browserProfiles[BrowserManager.resolveDefaultBrowserBundleId() ?? ""]
+                BrowserManager.open(url: url, profile: profile)
+            }
+            model.cancelSchedule(id: ref.linkId)
+        }
+
+        let previousOnChange = model.onChange
+        model.onChange = { [weak scheduler, weak model] in
+            previousOnChange?()
+            guard let scheduler, let model else { return }
+            scheduler.sync(with: model.allScheduledLinks())
+        }
+
+        scheduler.sync(with: model.allScheduledLinks())
+
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self,
+            selector: #selector(handleSchedulerWakeOrActivate),
+            name: NSWorkspace.didWakeNotification,
+            object: nil
+        )
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleSchedulerWakeOrActivate),
+            name: NSApplication.didBecomeActiveNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleSchedulerWakeOrActivate() {
+        guard let scheduler, let model = mainViewController?.model else { return }
+        scheduler.sync(with: model.allScheduledLinks())
     }
 
     public func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -254,6 +254,47 @@ final class AppModel {
         }
     }
 
+    func scheduleLink(id: UUID, at date: Date) {
+        updateNode(id: id) { node in
+            if case .link(var link) = node {
+                link.scheduledOpenAt = date
+                node = .link(link)
+            }
+        }
+    }
+
+    func cancelSchedule(id: UUID) {
+        updateNode(id: id) { node in
+            if case .link(var link) = node {
+                link.scheduledOpenAt = nil
+                node = .link(link)
+            }
+        }
+    }
+
+    func allScheduledLinks() -> [ScheduledLinkRef] {
+        var result: [ScheduledLinkRef] = []
+        for workspace in state.workspaces {
+            collectScheduled(in: workspace.items, workspaceId: workspace.id, into: &result)
+        }
+        return result
+    }
+
+    private func collectScheduled(in nodes: [Node], workspaceId: UUID, into result: inout [ScheduledLinkRef]) {
+        for node in nodes {
+            switch node {
+            case .link(let link):
+                if let fireAt = link.scheduledOpenAt {
+                    result.append(ScheduledLinkRef(workspaceId: workspaceId, linkId: link.id, url: link.url, fireAt: fireAt))
+                }
+            case .folder(let folder):
+                collectScheduled(in: folder.children, workspaceId: workspaceId, into: &result)
+            case .note:
+                break
+            }
+        }
+    }
+
     func updateLinkUrl(id: UUID, newUrl: String) {
         updateNode(id: id) { node in
             switch node {

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -356,6 +356,14 @@ final class MainViewController: NSViewController {
             self?.model.canPinMore ?? false
         }
 
+        nodeListViewController.onLinkScheduled = { [weak self] id, date in
+            self?.model.scheduleLink(id: id, at: date)
+        }
+
+        nodeListViewController.onLinkScheduleCleared = { [weak self] id in
+            self?.model.cancelSchedule(id: id)
+        }
+
         nodeListViewController.onChangeIconRequested = { [weak self] nodeId, anchorView in
             guard let self, let node = self.model.nodeById(nodeId) else { return }
             switch node {

--- a/Sources/ArcmarkCore/Models.swift
+++ b/Sources/ArcmarkCore/Models.swift
@@ -129,6 +129,7 @@ struct Link: Codable, Identifiable, Equatable, Sendable {
     var url: String
     var faviconPath: String?
     var customIcon: CustomIcon?
+    var scheduledOpenAt: Date?
 }
 
 struct Folder: Codable, Identifiable, Equatable, Sendable {

--- a/Sources/ArcmarkCore/Models.swift
+++ b/Sources/ArcmarkCore/Models.swift
@@ -230,6 +230,13 @@ struct NodeLocation: Equatable {
     var index: Int
 }
 
+struct ScheduledLinkRef: Equatable, Sendable {
+    let workspaceId: UUID
+    let linkId: UUID
+    let url: String
+    let fireAt: Date
+}
+
 enum WorkspaceMoveDirection {
     case left
     case right

--- a/Sources/ArcmarkCore/NodeCollectionViewItem.swift
+++ b/Sources/ArcmarkCore/NodeCollectionViewItem.swift
@@ -16,6 +16,7 @@ final class NodeCollectionViewItem: NSCollectionViewItem {
                    showDelete: Bool,
                    onDelete: (() -> Void)?,
                    isSelected: Bool,
+                   isScheduled: Bool = false,
                    tooltipURL: String? = nil) {
         view.alphaValue = 1
         view.layer?.transform = CATransform3DIdentity
@@ -28,6 +29,7 @@ final class NodeCollectionViewItem: NSCollectionViewItem {
             metrics: metrics,
             onDelete: onDelete,
             isSelected: isSelected,
+            isScheduled: isScheduled,
             tooltipURL: tooltipURL
         )
     }

--- a/Sources/ArcmarkCore/NodeCollectionViewItem.swift
+++ b/Sources/ArcmarkCore/NodeCollectionViewItem.swift
@@ -17,6 +17,7 @@ final class NodeCollectionViewItem: NSCollectionViewItem {
                    onDelete: (() -> Void)?,
                    isSelected: Bool,
                    isScheduled: Bool = false,
+                   scheduleBadgeBackgroundColor: NSColor? = nil,
                    tooltipURL: String? = nil) {
         view.alphaValue = 1
         view.layer?.transform = CATransform3DIdentity
@@ -30,6 +31,7 @@ final class NodeCollectionViewItem: NSCollectionViewItem {
             onDelete: onDelete,
             isSelected: isSelected,
             isScheduled: isScheduled,
+            scheduleBadgeBackgroundColor: scheduleBadgeBackgroundColor,
             tooltipURL: tooltipURL
         )
     }

--- a/Sources/ArcmarkCore/NodeRowView.swift
+++ b/Sources/ArcmarkCore/NodeRowView.swift
@@ -4,10 +4,13 @@ final class NodeRowView: BaseView {
     private let iconView = NSImageView()
     private let editableTitle = InlineEditableTextField()
     private let deleteButton = NSButton()
+    private let clockBadgeContainer = NSView()
+    private let clockBadgeHoverOverlay = NSView()
     private let clockIconView = NSImageView()
     private var isSelected = false
     private var showsDeleteButton = false
     private var isScheduled = false
+    private var scheduleBadgeBackgroundColor: NSColor?
     private var metrics = ListMetrics()
     private var onDelete: (() -> Void)?
     private var tooltipURL: String?
@@ -20,7 +23,10 @@ final class NodeRowView: BaseView {
     private var iconHeightConstraint: NSLayoutConstraint?
     private var titleTrailingToDeleteButton: NSLayoutConstraint!
     private var titleTrailingToEdge: NSLayoutConstraint!
-    private var titleTrailingToClock: NSLayoutConstraint!
+
+    private static let scheduleBadgeSize: CGFloat = 14
+    private static let scheduleBadgePadding: CGFloat = 1.5
+    private static var scheduleBadgeIconSize: CGFloat { scheduleBadgeSize - scheduleBadgePadding * 2 }
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -54,14 +60,25 @@ final class NodeRowView: BaseView {
         deleteButton.action = #selector(handleDelete)
         deleteButton.setButtonType(.momentaryChange)
 
+        clockBadgeContainer.translatesAutoresizingMaskIntoConstraints = false
+        clockBadgeContainer.wantsLayer = true
+        clockBadgeContainer.isHidden = true
+        clockBadgeContainer.layer?.cornerRadius = Self.scheduleBadgeSize / 2
+        clockBadgeContainer.layer?.masksToBounds = true
+
+        clockBadgeHoverOverlay.translatesAutoresizingMaskIntoConstraints = false
+        clockBadgeHoverOverlay.wantsLayer = true
+        clockBadgeHoverOverlay.isHidden = true
+
         clockIconView.translatesAutoresizingMaskIntoConstraints = false
         clockIconView.imageScaling = .scaleProportionallyDown
-        clockIconView.isHidden = true
 
         addSubview(iconView)
         addSubview(editableTitle)
         addSubview(deleteButton)
-        addSubview(clockIconView)
+        addSubview(clockBadgeContainer)
+        clockBadgeContainer.addSubview(clockBadgeHoverOverlay)
+        clockBadgeContainer.addSubview(clockIconView)
 
         iconLeadingConstraint = iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
         iconWidthConstraint = iconView.widthAnchor.constraint(equalToConstant: 26)
@@ -71,8 +88,6 @@ final class NodeRowView: BaseView {
             lessThanOrEqualTo: deleteButton.leadingAnchor, constant: -14)
         titleTrailingToEdge = editableTitle.trailingAnchor.constraint(
             lessThanOrEqualTo: trailingAnchor, constant: -16)
-        titleTrailingToClock = editableTitle.trailingAnchor.constraint(
-            lessThanOrEqualTo: clockIconView.leadingAnchor, constant: -8)
 
         NSLayoutConstraint.activate([
             iconLeadingConstraint!,
@@ -89,10 +104,20 @@ final class NodeRowView: BaseView {
             deleteButton.widthAnchor.constraint(equalToConstant: 22),
             deleteButton.heightAnchor.constraint(equalToConstant: 22),
 
-            clockIconView.trailingAnchor.constraint(equalTo: deleteButton.leadingAnchor, constant: -8),
-            clockIconView.centerYAnchor.constraint(equalTo: centerYAnchor),
-            clockIconView.widthAnchor.constraint(equalToConstant: ThemeConstants.Sizing.iconSmall),
-            clockIconView.heightAnchor.constraint(equalToConstant: ThemeConstants.Sizing.iconSmall)
+            clockBadgeContainer.centerXAnchor.constraint(equalTo: iconView.trailingAnchor),
+            clockBadgeContainer.centerYAnchor.constraint(equalTo: iconView.bottomAnchor),
+            clockBadgeContainer.widthAnchor.constraint(equalToConstant: Self.scheduleBadgeSize),
+            clockBadgeContainer.heightAnchor.constraint(equalToConstant: Self.scheduleBadgeSize),
+
+            clockBadgeHoverOverlay.leadingAnchor.constraint(equalTo: clockBadgeContainer.leadingAnchor),
+            clockBadgeHoverOverlay.trailingAnchor.constraint(equalTo: clockBadgeContainer.trailingAnchor),
+            clockBadgeHoverOverlay.topAnchor.constraint(equalTo: clockBadgeContainer.topAnchor),
+            clockBadgeHoverOverlay.bottomAnchor.constraint(equalTo: clockBadgeContainer.bottomAnchor),
+
+            clockIconView.centerXAnchor.constraint(equalTo: clockBadgeContainer.centerXAnchor),
+            clockIconView.centerYAnchor.constraint(equalTo: clockBadgeContainer.centerYAnchor),
+            clockIconView.widthAnchor.constraint(equalToConstant: Self.scheduleBadgeIconSize),
+            clockIconView.heightAnchor.constraint(equalToConstant: Self.scheduleBadgeIconSize)
         ])
 
     }
@@ -105,6 +130,7 @@ final class NodeRowView: BaseView {
                    onDelete: (() -> Void)?,
                    isSelected: Bool,
                    isScheduled: Bool = false,
+                   scheduleBadgeBackgroundColor: NSColor? = nil,
                    tooltipURL: String? = nil) {
         tooltipShowTask?.cancel()
         tooltipShowTask = nil
@@ -112,7 +138,8 @@ final class NodeRowView: BaseView {
         self.metrics = metrics
         self.isSelected = isSelected
         self.isScheduled = isScheduled
-        configureClockIcon()
+        self.scheduleBadgeBackgroundColor = scheduleBadgeBackgroundColor
+        configureClockBadge()
         updateVisualState()
         if editableTitle.isEditing {
             if editableTitle.text != title {
@@ -191,31 +218,37 @@ final class NodeRowView: BaseView {
 
     private func updateVisualState() {
         let showDelete: Bool
+        let showBadgeHoverOverlay: Bool
         if isSelected {
             layer?.backgroundColor = metrics.selectedBackgroundColor.cgColor
             showDelete = false
+            showBadgeHoverOverlay = false
         } else if isHovered {
             layer?.backgroundColor = metrics.hoverBackgroundColor.cgColor
             showDelete = showsDeleteButton
+            showBadgeHoverOverlay = true
         } else {
             layer?.backgroundColor = NSColor.clear.cgColor
             showDelete = false
+            showBadgeHoverOverlay = false
         }
 
         deleteButton.isHidden = !showDelete
-        clockIconView.isHidden = !isScheduled
+        clockBadgeContainer.isHidden = !isScheduled
+        clockBadgeHoverOverlay.isHidden = !showBadgeHoverOverlay
+        clockBadgeHoverOverlay.layer?.backgroundColor = metrics.hoverBackgroundColor.cgColor
 
-        titleTrailingToClock.isActive = isScheduled
-        titleTrailingToDeleteButton.isActive = !isScheduled && showDelete
-        titleTrailingToEdge.isActive = !isScheduled && !showDelete
+        titleTrailingToDeleteButton.isActive = showDelete
+        titleTrailingToEdge.isActive = !showDelete
     }
 
-    private func configureClockIcon() {
+    private func configureClockBadge() {
         guard isScheduled else { return }
-        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        let config = NSImage.SymbolConfiguration(pointSize: Self.scheduleBadgeIconSize, weight: .bold)
         clockIconView.image = NSImage(systemSymbolName: "clock.fill", accessibilityDescription: "Scheduled")?
             .withSymbolConfiguration(config)
         clockIconView.contentTintColor = ThemeConstants.Colors.darkGray
-            .withAlphaComponent(ThemeConstants.Opacity.medium)
+            .withAlphaComponent(ThemeConstants.Opacity.high)
+        clockBadgeContainer.layer?.backgroundColor = (scheduleBadgeBackgroundColor ?? .clear).cgColor
     }
 }

--- a/Sources/ArcmarkCore/NodeRowView.swift
+++ b/Sources/ArcmarkCore/NodeRowView.swift
@@ -4,8 +4,10 @@ final class NodeRowView: BaseView {
     private let iconView = NSImageView()
     private let editableTitle = InlineEditableTextField()
     private let deleteButton = NSButton()
+    private let clockIconView = NSImageView()
     private var isSelected = false
     private var showsDeleteButton = false
+    private var isScheduled = false
     private var metrics = ListMetrics()
     private var onDelete: (() -> Void)?
     private var tooltipURL: String?
@@ -18,6 +20,7 @@ final class NodeRowView: BaseView {
     private var iconHeightConstraint: NSLayoutConstraint?
     private var titleTrailingToDeleteButton: NSLayoutConstraint!
     private var titleTrailingToEdge: NSLayoutConstraint!
+    private var titleTrailingToClock: NSLayoutConstraint!
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -51,9 +54,14 @@ final class NodeRowView: BaseView {
         deleteButton.action = #selector(handleDelete)
         deleteButton.setButtonType(.momentaryChange)
 
+        clockIconView.translatesAutoresizingMaskIntoConstraints = false
+        clockIconView.imageScaling = .scaleProportionallyDown
+        clockIconView.isHidden = true
+
         addSubview(iconView)
         addSubview(editableTitle)
         addSubview(deleteButton)
+        addSubview(clockIconView)
 
         iconLeadingConstraint = iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16)
         iconWidthConstraint = iconView.widthAnchor.constraint(equalToConstant: 26)
@@ -63,6 +71,8 @@ final class NodeRowView: BaseView {
             lessThanOrEqualTo: deleteButton.leadingAnchor, constant: -14)
         titleTrailingToEdge = editableTitle.trailingAnchor.constraint(
             lessThanOrEqualTo: trailingAnchor, constant: -16)
+        titleTrailingToClock = editableTitle.trailingAnchor.constraint(
+            lessThanOrEqualTo: clockIconView.leadingAnchor, constant: -8)
 
         NSLayoutConstraint.activate([
             iconLeadingConstraint!,
@@ -77,7 +87,12 @@ final class NodeRowView: BaseView {
             deleteButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
             deleteButton.centerYAnchor.constraint(equalTo: centerYAnchor),
             deleteButton.widthAnchor.constraint(equalToConstant: 22),
-            deleteButton.heightAnchor.constraint(equalToConstant: 22)
+            deleteButton.heightAnchor.constraint(equalToConstant: 22),
+
+            clockIconView.trailingAnchor.constraint(equalTo: deleteButton.leadingAnchor, constant: -8),
+            clockIconView.centerYAnchor.constraint(equalTo: centerYAnchor),
+            clockIconView.widthAnchor.constraint(equalToConstant: ThemeConstants.Sizing.iconSmall),
+            clockIconView.heightAnchor.constraint(equalToConstant: ThemeConstants.Sizing.iconSmall)
         ])
 
     }
@@ -89,12 +104,15 @@ final class NodeRowView: BaseView {
                    metrics: ListMetrics,
                    onDelete: (() -> Void)?,
                    isSelected: Bool,
+                   isScheduled: Bool = false,
                    tooltipURL: String? = nil) {
         tooltipShowTask?.cancel()
         tooltipShowTask = nil
         self.tooltipURL = tooltipURL
         self.metrics = metrics
         self.isSelected = isSelected
+        self.isScheduled = isScheduled
+        configureClockIcon()
         updateVisualState()
         if editableTitle.isEditing {
             if editableTitle.text != title {
@@ -185,7 +203,19 @@ final class NodeRowView: BaseView {
         }
 
         deleteButton.isHidden = !showDelete
-        titleTrailingToDeleteButton.isActive = showDelete
-        titleTrailingToEdge.isActive = !showDelete
+        clockIconView.isHidden = !isScheduled
+
+        titleTrailingToClock.isActive = isScheduled
+        titleTrailingToDeleteButton.isActive = !isScheduled && showDelete
+        titleTrailingToEdge.isActive = !isScheduled && !showDelete
+    }
+
+    private func configureClockIcon() {
+        guard isScheduled else { return }
+        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .medium)
+        clockIconView.image = NSImage(systemSymbolName: "clock.fill", accessibilityDescription: "Scheduled")?
+            .withSymbolConfiguration(config)
+        clockIconView.contentTintColor = ThemeConstants.Colors.darkGray
+            .withAlphaComponent(ThemeConstants.Opacity.medium)
     }
 }

--- a/Sources/ArcmarkCore/Services/SchedulerService.swift
+++ b/Sources/ArcmarkCore/Services/SchedulerService.swift
@@ -5,10 +5,18 @@ import os
 final class SchedulerService {
     private var timers: [UUID: DispatchSourceTimer] = [:]
     private let logger = Logger(subsystem: "com.arcmark.app", category: "scheduler")
+    private var isSyncing = false
 
     var onFire: ((ScheduledLinkRef) -> Void)?
 
     func sync(with schedules: [ScheduledLinkRef]) {
+        // Reentry guard: onFire mutates model state, which triggers onChange,
+        // which calls sync again. Without this, overdue refs after the first
+        // would be fired by both the recursive sync and the outer loop.
+        guard !isSyncing else { return }
+        isSyncing = true
+        defer { isSyncing = false }
+
         for (_, timer) in timers { timer.cancel() }
         timers.removeAll()
 

--- a/Sources/ArcmarkCore/Services/SchedulerService.swift
+++ b/Sources/ArcmarkCore/Services/SchedulerService.swift
@@ -1,0 +1,40 @@
+import Foundation
+import os
+
+@MainActor
+final class SchedulerService {
+    private var timers: [UUID: DispatchSourceTimer] = [:]
+    private let logger = Logger(subsystem: "com.arcmark.app", category: "scheduler")
+
+    var onFire: ((ScheduledLinkRef) -> Void)?
+
+    func sync(with schedules: [ScheduledLinkRef]) {
+        for (_, timer) in timers { timer.cancel() }
+        timers.removeAll()
+
+        let now = Date()
+        for ref in schedules {
+            if ref.fireAt <= now {
+                logger.debug("Firing overdue \(ref.linkId.uuidString, privacy: .public)")
+                onFire?(ref)
+            } else {
+                arm(ref)
+            }
+        }
+    }
+
+    private func arm(_ ref: ScheduledLinkRef) {
+        let delay = max(0, ref.fireAt.timeIntervalSinceNow)
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + delay)
+        timer.setEventHandler { [weak self] in
+            guard let self else { return }
+            self.timers[ref.linkId]?.cancel()
+            self.timers.removeValue(forKey: ref.linkId)
+            self.logger.debug("Firing scheduled \(ref.linkId.uuidString, privacy: .public)")
+            self.onFire?(ref)
+        }
+        timers[ref.linkId] = timer
+        timer.resume()
+    }
+}

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -645,6 +645,7 @@ extension NodeListViewController: NSCollectionViewDataSource {
                 },
                 isSelected: isSelected,
                 isScheduled: link.scheduledOpenAt != nil,
+                scheduleBadgeBackgroundColor: workspaceColor.backgroundColor,
                 tooltipURL: link.url
             )
 

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -55,6 +55,8 @@ final class NodeListViewController: NSViewController {
     var onPinLink: ((UUID) -> Void)?
     var canPinLink: (() -> Bool)?
     var onChangeIconRequested: ((UUID, NSView) -> Void)?
+    var onLinkScheduled: ((UUID, Date) -> Void)?
+    var onLinkScheduleCleared: ((UUID) -> Void)?
 
     // Data provider closure
     var nodeProvider: (() -> [Node])?
@@ -970,6 +972,31 @@ extension NodeListViewController: NSMenuDelegate {
             changeIcon.representedObject = node.id
             menu.addItem(changeIcon)
 
+            let scheduleItem = NSMenuItem(title: "Schedule", action: nil, keyEquivalent: "")
+            let scheduleSubmenu = NSMenu()
+            let presets: [(String, Int)] = [
+                ("In 1 day", 1),
+                ("In 2 days", 2),
+                ("In 3 days", 3),
+                ("In 1 week", 7),
+                ("In 2 weeks", 14),
+            ]
+            for (label, days) in presets {
+                let item = NSMenuItem(title: label, action: #selector(contextScheduleLink(_:)), keyEquivalent: "")
+                item.target = self
+                item.representedObject = ScheduleMenuPayload(linkId: node.id, days: days)
+                scheduleSubmenu.addItem(item)
+            }
+            if case .link(let link) = node, link.scheduledOpenAt != nil {
+                scheduleSubmenu.addItem(.separator())
+                let clear = NSMenuItem(title: "Clear Schedule", action: #selector(contextClearSchedule(_:)), keyEquivalent: "")
+                clear.target = self
+                clear.representedObject = node.id
+                scheduleSubmenu.addItem(clear)
+            }
+            scheduleItem.submenu = scheduleSubmenu
+            menu.addItem(scheduleItem)
+
             let moveMenu = NSMenuItem(title: "Move to", action: nil, keyEquivalent: "")
             let submenu = NSMenu()
             if let workspaces = workspacesProvider?(), let currentId = currentWorkspaceIdProvider?() {
@@ -1101,6 +1128,17 @@ extension NodeListViewController: NSMenuDelegate {
         onChangeIconRequested?(nodeId, item.view)
     }
 
+    @objc private func contextScheduleLink(_ sender: NSMenuItem) {
+        guard let payload = sender.representedObject as? ScheduleMenuPayload else { return }
+        guard let fireDate = Calendar.current.date(byAdding: .day, value: payload.days, to: Date()) else { return }
+        onLinkScheduled?(payload.linkId, fireDate)
+    }
+
+    @objc private func contextClearSchedule(_ sender: NSMenuItem) {
+        guard let linkId = sender.representedObject as? UUID else { return }
+        onLinkScheduleCleared?(linkId)
+    }
+
     private func populateBulkContextMenu(_ menu: NSMenu) {
         let count = selectedNodeIds.count
 
@@ -1222,6 +1260,15 @@ private struct NodeListRow {
 
     var id: UUID {
         node.id
+    }
+}
+
+private final class ScheduleMenuPayload {
+    let linkId: UUID
+    let days: Int
+    init(linkId: UUID, days: Int) {
+        self.linkId = linkId
+        self.days = days
     }
 }
 

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -976,17 +976,19 @@ extension NodeListViewController: NSMenuDelegate {
 
             let scheduleItem = NSMenuItem(title: "Schedule", action: nil, keyEquivalent: "")
             let scheduleSubmenu = NSMenu()
-            let presets: [(String, Int)] = [
-                ("In 1 day", 1),
-                ("In 2 days", 2),
-                ("In 3 days", 3),
-                ("In 1 week", 7),
-                ("In 2 weeks", 14),
+
+            let presets: [(String, Calendar.Component, Int)] = [
+                ("In 1 hour", .hour, 1),
+                ("In 1 day", .day, 1),
+                ("In 2 days", .day, 2),
+                ("In 3 days", .day, 3),
+                ("In 1 week", .day, 7),
+                ("In 2 weeks", .day, 14),
             ]
-            for (label, days) in presets {
+            for (label, component, value) in presets {
                 let item = NSMenuItem(title: label, action: #selector(contextScheduleLink(_:)), keyEquivalent: "")
                 item.target = self
-                item.representedObject = ScheduleMenuPayload(linkId: node.id, days: days)
+                item.representedObject = ScheduleMenuPayload(linkId: node.id, component: component, value: value)
                 scheduleSubmenu.addItem(item)
             }
             if case .link(let link) = node, link.scheduledOpenAt != nil {
@@ -1132,7 +1134,7 @@ extension NodeListViewController: NSMenuDelegate {
 
     @objc private func contextScheduleLink(_ sender: NSMenuItem) {
         guard let payload = sender.representedObject as? ScheduleMenuPayload else { return }
-        guard let fireDate = Calendar.current.date(byAdding: .day, value: payload.days, to: Date()) else { return }
+        guard let fireDate = Calendar.current.date(byAdding: payload.component, value: payload.value, to: Date()) else { return }
         onLinkScheduled?(payload.linkId, fireDate)
     }
 
@@ -1267,10 +1269,12 @@ private struct NodeListRow {
 
 private final class ScheduleMenuPayload {
     let linkId: UUID
-    let days: Int
-    init(linkId: UUID, days: Int) {
+    let component: Calendar.Component
+    let value: Int
+    init(linkId: UUID, component: Calendar.Component, value: Int) {
         self.linkId = linkId
-        self.days = days
+        self.component = component
+        self.value = value
     }
 }
 

--- a/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
+++ b/Sources/ArcmarkCore/ViewControllers/NodeListViewController.swift
@@ -644,6 +644,7 @@ extension NodeListViewController: NSCollectionViewDataSource {
                     self?.clearSelections()
                 },
                 isSelected: isSelected,
+                isScheduled: link.scheduledOpenAt != nil,
                 tooltipURL: link.url
             )
 

--- a/Tests/ArcmarkTests/ModelTests.swift
+++ b/Tests/ArcmarkTests/ModelTests.swift
@@ -862,6 +862,103 @@ final class ModelTests: XCTestCase {
         }
     }
 
+    // MARK: - Scheduled Link Tests
+
+    func testLinkRoundTripWithSchedule() throws {
+        let fireAt = Date(timeIntervalSince1970: 1_800_000_000)
+        let link = Link(
+            id: UUID(),
+            title: "Scheduled",
+            url: "https://example.com",
+            faviconPath: nil,
+            customIcon: nil,
+            scheduledOpenAt: fireAt
+        )
+        let data = try JSONEncoder().encode(link)
+        let decoded = try JSONDecoder().decode(Link.self, from: data)
+        XCTAssertEqual(decoded.scheduledOpenAt, fireAt)
+    }
+
+    func testLinkDecodesLegacyMissingScheduledOpenAt() throws {
+        let legacyJSON = """
+        {
+            "id": "00000000-0000-0000-0000-0000000000aa",
+            "title": "Legacy",
+            "url": "https://legacy.example.com"
+        }
+        """.data(using: .utf8)!
+        let link = try JSONDecoder().decode(Link.self, from: legacyJSON)
+        XCTAssertNil(link.scheduledOpenAt)
+    }
+
+    func testScheduleLinkSetsDate() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        let linkId = model.addLink(urlString: "https://a.com", title: "A", parentId: nil)
+        let fireAt = Date(timeIntervalSinceNow: 60)
+        model.scheduleLink(id: linkId, at: fireAt)
+
+        guard let node = model.nodeById(linkId), case .link(let link) = node else {
+            XCTFail("Expected link"); return
+        }
+        XCTAssertEqual(link.scheduledOpenAt, fireAt)
+    }
+
+    func testCancelScheduleClearsDate() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        let linkId = model.addLink(urlString: "https://a.com", title: "A", parentId: nil)
+        model.scheduleLink(id: linkId, at: Date(timeIntervalSinceNow: 60))
+        model.cancelSchedule(id: linkId)
+
+        guard let node = model.nodeById(linkId), case .link(let link) = node else {
+            XCTFail("Expected link"); return
+        }
+        XCTAssertNil(link.scheduledOpenAt)
+    }
+
+    func testDeleteNodeRemovesScheduledLinkFromState() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        let linkId = model.addLink(urlString: "https://a.com", title: "A", parentId: nil)
+        model.scheduleLink(id: linkId, at: Date(timeIntervalSinceNow: 60))
+        XCTAssertEqual(model.allScheduledLinks().count, 1)
+
+        model.deleteNode(id: linkId)
+        XCTAssertEqual(model.allScheduledLinks().count, 0)
+    }
+
+    func testAllScheduledLinksWalksFoldersAndWorkspaces() {
+        let store = makeStore()
+        store.save(DataStore.defaultState())
+        let model = AppModel(store: store)
+
+        // Workspace A: nested folder containing a scheduled link
+        let folderId = model.addFolder(name: "Folder", parentId: nil)
+        let nestedFolderId = model.addFolder(name: "Nested", parentId: folderId)
+        let nestedLinkId = model.addLink(urlString: "https://nested.com", title: "Nested", parentId: nestedFolderId)
+        model.scheduleLink(id: nestedLinkId, at: Date(timeIntervalSince1970: 1_000_000))
+
+        // Workspace B: top-level scheduled link
+        let workspaceBId = model.createWorkspace(name: "B", colorId: .moss)
+        let topLinkId = model.addLink(urlString: "https://top.com", title: "Top", parentId: nil)
+        model.scheduleLink(id: topLinkId, at: Date(timeIntervalSince1970: 2_000_000))
+
+        // Switch back so we exercise cross-workspace traversal
+        model.selectWorkspace(id: workspaceBId)
+
+        let scheduled = model.allScheduledLinks()
+        XCTAssertEqual(scheduled.count, 2)
+        let linkIds = Set(scheduled.map { $0.linkId })
+        XCTAssertEqual(linkIds, Set([nestedLinkId, topLinkId]))
+    }
+
     func testMultipleBrowserProfiles() {
         let store = makeStore()
         store.save(DataStore.defaultState())


### PR DESCRIPTION
## Summary
- Add optional `scheduledOpenAt` to `Link` with `scheduleLink` / `cancelSchedule` / `allScheduledLinks` on `AppModel`.
- Introduce `SchedulerService` (DispatchSourceTimer-based) wired in `AppDelegate`, with re-sync on wake and app activation, plus a reentrancy guard so overdue fires don't double-trigger.
- Add a "Schedule" submenu to the link context menu with presets (In 1 hour, 1/2/3 days, 1/2 weeks) and "Clear Schedule".
- Surface a clock badge on the favicon corner for scheduled links and cover the new model APIs with round-trip and traversal tests.

## Test plan
- [ ] `swift test`
- [ ] Schedule a link via the context menu and confirm the clock badge appears
- [ ] Wait for fire (or use "In 1 hour" + system clock change) and confirm the link opens in the right browser profile and the schedule clears
- [ ] Clear an active schedule from the submenu and confirm the badge disappears
- [ ] Sleep/wake or relaunch with an overdue schedule and confirm it fires on resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)