### PR TITLE
feat(sidebar): add overscroll space below the node list

### DIFF
--- a/Sources/ArcmarkCore/Constants.swift
+++ b/Sources/ArcmarkCore/Constants.swift
@@ -33,6 +33,7 @@ struct LayoutConstants {
 struct ListMetrics {
     let rowHeight: CGFloat = 40
     let verticalGap: CGFloat = 4
+    let overscrollBottom: CGFloat = 150
     let leftPadding: CGFloat = 8
     let iconSize: CGFloat = 20
     let indentWidth: CGFloat = 16

--- a/Sources/ArcmarkCore/ListFlowLayout.swift
+++ b/Sources/ArcmarkCore/ListFlowLayout.swift
@@ -9,7 +9,7 @@ final class ListFlowLayout: NSCollectionViewFlowLayout {
         scrollDirection = .vertical
         minimumLineSpacing = metrics.verticalGap
         minimumInteritemSpacing = 0
-        sectionInset = NSEdgeInsets(top: metrics.verticalGap, left: 0, bottom: metrics.verticalGap, right: 0)
+        sectionInset = NSEdgeInsets(top: metrics.verticalGap, left: 0, bottom: metrics.overscrollBottom, right: 0)
     }
 
     required init?(coder: NSCoder) {
@@ -18,7 +18,7 @@ final class ListFlowLayout: NSCollectionViewFlowLayout {
         scrollDirection = .vertical
         minimumLineSpacing = metrics.verticalGap
         minimumInteritemSpacing = 0
-        sectionInset = NSEdgeInsets(top: metrics.verticalGap, left: 0, bottom: metrics.verticalGap, right: 0)
+        sectionInset = NSEdgeInsets(top: metrics.verticalGap, left: 0, bottom: metrics.overscrollBottom, right: 0)
     }
 
     override func prepare() {


### PR DESCRIPTION
## Summary

When the sidebar's node list fills the entire visible area, the last item sits flush against the bottom edge and scrolling stops dead — there's no breathing room. This PR adds 150pt of overscroll space below the last item so the list feels less cramped in dense workspaces.

## What changed

- Added `overscrollBottom: CGFloat = 150` to `ListMetrics` (`Sources/ArcmarkCore/Constants.swift`).
- Wired it into `ListFlowLayout`'s `sectionInset.bottom` in place of the previous `verticalGap` (4pt) value.

Because the scrollable area in the sidebar is the `NSCollectionView`'s content rect, increasing the bottom section inset extends the scrollable height beyond the last row — which is exactly what we want for overscroll. The top inset is unchanged.

## Why this approach

`sectionInset` is the idiomatic NSCollectionView knob for this — no extra views, no scroll-view content-inset trickery, and it composes correctly with the existing batch-update animations and drop-indicator math (which already reference `listMetrics.verticalGap` for their own concerns, not for bottom padding).

The single tunable lives in one place (`ListMetrics.overscrollBottom`), so future tweaks are a one-line change.

## Test plan

- [ ] Open a workspace with enough items to fill the sidebar vertically.
- [ ] Confirm you can scroll past the last item and see ~150pt of empty space below it.
- [ ] Confirm short workspaces (no scroll needed) still look correct — the extra inset only shows when the user actively scrolls.
- [ ] Drag-and-drop reordering, including dropping at the very bottom of the list, still works.
- [ ] Drop indicator line for "insert after last item" still appears at the right position.
- [ ] Search-filtered lists scroll correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)