### PR TITLE
feat: Arcmark agent skill + HTTP agent API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,33 @@ To import bookmarks from Arc browser:
 
 Arc stores your workspace locally in `~/Library/Application Support/Arc/StorableSidebar.json`. Arcmark parses this file to recreate exactly the same folder and spaces structure you've had previously.
 
+## Agent Skill
+
+Arcmark ships an agent skill in `skills/arcmark/` that lets Claude Code (and
+other skill-aware agents) organize bookmarks, folders, and notes on your
+behalf while the app is running. Two ways to install it:
+
+**Option 1 — `npx skills`** (installs into every supported agent at once):
+
+```bash
+npx skills add Geek-1001/arcmark
+```
+
+**Option 2 — copy the folder directly.** Grab `skills/arcmark/` from this
+repo and drop it into the skills directory of whichever agent you use,
+for example:
+
+```bash
+# Claude Code (project-local)
+cp -R skills/arcmark .claude/skills/
+
+# Claude Code (user-wide)
+cp -R skills/arcmark ~/.claude/skills/
+```
+
+Arcmark must be running for the skill to work — it talks to a local HTTP
+server inside the app.
+
 ## Building from Source
 
 ### Prerequisites

--- a/Sources/ArcmarkCore/AppDelegate.swift
+++ b/Sources/ArcmarkCore/AppDelegate.swift
@@ -139,7 +139,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
         agentEndpointFileURL = url
         try? FileManager.default.removeItem(at: url)
 
-        Task { @MainActor [weak self, weak noteServer] in
+        Task { @MainActor [weak noteServer] in
             for _ in 0..<200 {
                 if let port = noteServer?.port, port > 0 {
                     let payload: [String: Any] = [
@@ -150,7 +150,6 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
                     if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]) {
                         try? data.write(to: url, options: [.atomic])
                     }
-                    self?.agentEndpointFileURL = url
                     return
                 }
                 try? await Task.sleep(nanoseconds: 50_000_000)

--- a/Sources/ArcmarkCore/AppDelegate.swift
+++ b/Sources/ArcmarkCore/AppDelegate.swift
@@ -13,6 +13,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
     private var updaterController: SPUStandardUpdaterController!
     private var noteServer: NoteServer?
     private var scheduler: SchedulerService?
+    private var agentEndpointFileURL: URL?
 
     // Attachment state
     private var isAttachmentMode: Bool = false
@@ -39,6 +40,7 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
         noteServer.start()
         mainViewController.noteServer = noteServer
         self.noteServer = noteServer
+        publishAgentEndpoint(noteServer: noteServer)
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 340, height: 680),
@@ -127,6 +129,33 @@ public final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegat
             saveWindowFrame(window)
         }
         noteServer?.stop()
+        if let agentEndpointFileURL {
+            try? FileManager.default.removeItem(at: agentEndpointFileURL)
+        }
+    }
+
+    private func publishAgentEndpoint(noteServer: NoteServer) {
+        let url = DataStore().agentEndpointFileURL()
+        agentEndpointFileURL = url
+        try? FileManager.default.removeItem(at: url)
+
+        Task { @MainActor [weak self, weak noteServer] in
+            for _ in 0..<200 {
+                if let port = noteServer?.port, port > 0 {
+                    let payload: [String: Any] = [
+                        "port": Int(port),
+                        "host": "127.0.0.1",
+                        "schemaVersion": 1
+                    ]
+                    if let data = try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted]) {
+                        try? data.write(to: url, options: [.atomic])
+                    }
+                    self?.agentEndpointFileURL = url
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 50_000_000)
+            }
+        }
     }
 
     public func windowDidResize(_ notification: Notification) {

--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -134,26 +134,48 @@ final class AppModel {
 
     @discardableResult
     func addFolder(name: String, parentId: UUID?, isExpanded: Bool = true) -> UUID {
+        addFolder(name: name, workspaceId: currentWorkspace.id, parentId: parentId, isExpanded: isExpanded) ?? UUID()
+    }
+
+    @discardableResult
+    func addFolder(name: String, workspaceId: UUID, parentId: UUID?, isExpanded: Bool = true) -> UUID? {
+        guard state.workspaces.contains(where: { $0.id == workspaceId }) else { return nil }
         let folder = Folder(id: UUID(), name: name, children: [], isExpanded: isExpanded)
-        let node = Node.folder(folder)
-        insertNode(node, parentId: parentId)
+        updateWorkspace(id: workspaceId) { workspace in
+            insertNode(.folder(folder), parentId: parentId, index: nil, nodes: &workspace.items)
+        }
         return folder.id
     }
 
     @discardableResult
     func addLink(urlString: String, title: String, parentId: UUID?) -> UUID {
+        addLink(urlString: urlString, title: title, workspaceId: currentWorkspace.id, parentId: parentId) ?? UUID()
+    }
+
+    @discardableResult
+    func addLink(urlString: String, title: String, workspaceId: UUID, parentId: UUID?) -> UUID? {
+        guard state.workspaces.contains(where: { $0.id == workspaceId }) else { return nil }
         let link = Link(id: UUID(), title: title, url: urlString, faviconPath: nil)
-        let node = Node.link(link)
-        insertNode(node, parentId: parentId)
+        updateWorkspace(id: workspaceId) { workspace in
+            insertNode(.link(link), parentId: parentId, index: nil, nodes: &workspace.items)
+        }
         logger.debug("Added link \(title, privacy: .public) -> \(urlString, privacy: .public)")
         return link.id
     }
 
     @discardableResult
     func addNote(title: String, parentId: UUID?, content: String = "") -> UUID {
+        addNote(title: title, workspaceId: currentWorkspace.id, parentId: parentId, content: content) ?? UUID()
+    }
+
+    @discardableResult
+    func addNote(title: String, workspaceId: UUID, parentId: UUID?, content: String = "") -> UUID? {
+        guard state.workspaces.contains(where: { $0.id == workspaceId }) else { return nil }
         let note = Note(id: UUID(), title: title, customIcon: nil)
         try? noteStorage.write(id: note.id, content: content)
-        insertNode(.note(note), parentId: parentId)
+        updateWorkspace(id: workspaceId) { workspace in
+            insertNode(.note(note), parentId: parentId, index: nil, nodes: &workspace.items)
+        }
         return note.id
     }
 
@@ -174,8 +196,9 @@ final class AppModel {
     }
 
     func deleteNode(id: UUID) {
+        guard let wsId = workspaceIdContaining(nodeId: id) else { return }
         var removed: Node?
-        updateWorkspace(id: currentWorkspace.id) { workspace in
+        updateWorkspace(id: wsId) { workspace in
             removed = removeNode(id: id, nodes: &workspace.items)
         }
         if let node = removed {
@@ -199,10 +222,12 @@ final class AppModel {
     }
 
     func moveNode(id: UUID, toParentId: UUID?, index: Int) {
-        guard let location = findNodeLocation(id: id, nodes: currentWorkspace.items) else { return }
-        if let toParentId, isDescendant(nodeId: toParentId, in: id) { return }
+        guard let sourceWsId = workspaceIdContaining(nodeId: id),
+              let sourceWs = state.workspaces.first(where: { $0.id == sourceWsId }),
+              let location = findNodeLocation(id: id, nodes: sourceWs.items) else { return }
+        if let toParentId, isDescendant(nodeId: toParentId, ofAncestor: id, in: sourceWs.items) { return }
 
-        updateWorkspace(id: currentWorkspace.id) { workspace in
+        updateWorkspace(id: sourceWsId) { workspace in
             guard let removedNode = removeNode(id: id, nodes: &workspace.items) else { return }
 
             var targetIndex = max(0, index)
@@ -215,15 +240,37 @@ final class AppModel {
     }
 
     func moveNodeToWorkspace(id: UUID, workspaceId: UUID) {
-        guard workspaceId != currentWorkspace.id else { return }
+        moveNodeToWorkspace(id: id, workspaceId: workspaceId, parentId: nil, index: nil)
+    }
+
+    func moveNodeToWorkspace(id: UUID, workspaceId: UUID, parentId: UUID?, index: Int?) {
+        guard state.workspaces.contains(where: { $0.id == workspaceId }) else { return }
+        guard let sourceWsId = workspaceIdContaining(nodeId: id) else { return }
+        guard sourceWsId != workspaceId else {
+            // Same-workspace move — delegate to moveNode if a target was provided.
+            if let index {
+                moveNode(id: id, toParentId: parentId, index: index)
+            }
+            return
+        }
+        if let parentId,
+           let destWs = state.workspaces.first(where: { $0.id == workspaceId }),
+           findNodeLocation(id: parentId, nodes: destWs.items) == nil {
+            return
+        }
+
         var removedNode: Node?
-        updateWorkspace(id: currentWorkspace.id) { workspace in
+        updateWorkspace(id: sourceWsId, notify: false) { workspace in
             removedNode = removeNode(id: id, nodes: &workspace.items)
         }
-        guard let node = removedNode else { return }
+        guard let node = removedNode else {
+            // Restore notification so observers see the no-op revert if any.
+            persist()
+            return
+        }
 
         updateWorkspace(id: workspaceId) { workspace in
-            workspace.items.append(node)
+            insertNode(node, parentId: parentId, index: index, nodes: &workspace.items)
         }
     }
 
@@ -485,7 +532,8 @@ final class AppModel {
     }
 
     private func updateNode(id: UUID, notify: Bool = true, _ mutate: (inout Node) -> Void) {
-        updateWorkspace(id: currentWorkspace.id, notify: notify) { workspace in
+        guard let wsId = workspaceIdContaining(nodeId: id) else { return }
+        updateWorkspace(id: wsId, notify: notify) { workspace in
             _ = updateNode(id: id, nodes: &workspace.items, mutate)
         }
     }
@@ -611,6 +659,20 @@ final class AppModel {
     private func isDescendant(nodeId: UUID, in potentialAncestorId: UUID) -> Bool {
         guard let ancestor = nodeById(potentialAncestorId, nodes: currentWorkspace.items) else { return false }
         return containsNode(nodeId, within: ancestor)
+    }
+
+    private func isDescendant(nodeId: UUID, ofAncestor ancestorId: UUID, in nodes: [Node]) -> Bool {
+        guard let ancestor = nodeById(ancestorId, nodes: nodes) else { return false }
+        return containsNode(nodeId, within: ancestor)
+    }
+
+    private func workspaceIdContaining(nodeId: UUID) -> UUID? {
+        for workspace in state.workspaces {
+            if findNodeLocation(id: nodeId, nodes: workspace.items) != nil {
+                return workspace.id
+            }
+        }
+        return nil
     }
 
     private func nodeById(_ id: UUID, nodes: [Node]) -> Node? {

--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -134,7 +134,10 @@ final class AppModel {
 
     @discardableResult
     func addFolder(name: String, parentId: UUID?, isExpanded: Bool = true) -> UUID {
-        addFolder(name: name, workspaceId: currentWorkspace.id, parentId: parentId, isExpanded: isExpanded) ?? UUID()
+        guard let id = addFolder(name: name, workspaceId: currentWorkspace.id, parentId: parentId, isExpanded: isExpanded) else {
+            preconditionFailure("currentWorkspace is missing from state.workspaces")
+        }
+        return id
     }
 
     @discardableResult
@@ -149,7 +152,10 @@ final class AppModel {
 
     @discardableResult
     func addLink(urlString: String, title: String, parentId: UUID?) -> UUID {
-        addLink(urlString: urlString, title: title, workspaceId: currentWorkspace.id, parentId: parentId) ?? UUID()
+        guard let id = addLink(urlString: urlString, title: title, workspaceId: currentWorkspace.id, parentId: parentId) else {
+            preconditionFailure("currentWorkspace is missing from state.workspaces")
+        }
+        return id
     }
 
     @discardableResult
@@ -165,7 +171,10 @@ final class AppModel {
 
     @discardableResult
     func addNote(title: String, parentId: UUID?, content: String = "") -> UUID {
-        addNote(title: title, workspaceId: currentWorkspace.id, parentId: parentId, content: content) ?? UUID()
+        guard let id = addNote(title: title, workspaceId: currentWorkspace.id, parentId: parentId, content: content) else {
+            preconditionFailure("currentWorkspace is missing from state.workspaces")
+        }
+        return id
     }
 
     @discardableResult

--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -263,11 +263,7 @@ final class AppModel {
         updateWorkspace(id: sourceWsId, notify: false) { workspace in
             removedNode = removeNode(id: id, nodes: &workspace.items)
         }
-        guard let node = removedNode else {
-            // Restore notification so observers see the no-op revert if any.
-            persist()
-            return
-        }
+        guard let node = removedNode else { return }
 
         updateWorkspace(id: workspaceId) { workspace in
             insertNode(node, parentId: parentId, index: index, nodes: &workspace.items)

--- a/Sources/ArcmarkCore/AppModel.swift
+++ b/Sources/ArcmarkCore/AppModel.swift
@@ -452,6 +452,19 @@ final class AppModel {
         nodeById(id, nodes: currentWorkspace.items)
     }
 
+    func nodeAcrossWorkspaces(id: UUID) -> Node? {
+        for workspace in state.workspaces {
+            if let node = nodeById(id, nodes: workspace.items) {
+                return node
+            }
+        }
+        return nil
+    }
+
+    func workspaceId(forNodeId id: UUID) -> UUID? {
+        workspaceIdContaining(nodeId: id)
+    }
+
     func findNode(id: UUID, in nodes: [Node]) -> Node? {
         for node in nodes {
             if node.id == id {

--- a/Sources/ArcmarkCore/DataStore.swift
+++ b/Sources/ArcmarkCore/DataStore.swift
@@ -67,6 +67,10 @@ final class DataStore {
         notesDirectory().appendingPathComponent("\(id.uuidString).md")
     }
 
+    func agentEndpointFileURL() -> URL {
+        baseDirectory.appendingPathComponent("agent-endpoint.json")
+    }
+
     private func ensureDirectories() {
         if !fileManager.fileExists(atPath: baseDirectory.path) {
             try? fileManager.createDirectory(at: baseDirectory, withIntermediateDirectories: true)

--- a/Sources/ArcmarkCore/Notes/NoteServer.swift
+++ b/Sources/ArcmarkCore/Notes/NoteServer.swift
@@ -188,19 +188,66 @@ final class NoteServer {
         case ("GET", let path) where path.hasPrefix("/editor/"):
             let relative = String(path.dropFirst("/editor/".count))
             serveEditorAsset(relative: relative, on: connection)
+
+        // State / queries
+        case ("GET", "/api/state"):
+            handleGetState(on: connection)
+        case ("GET", "/api/workspaces"):
+            handleListWorkspaces(on: connection)
+        case ("GET", let path) where path.hasPrefix("/api/workspaces/") && path.hasSuffix("/tree"):
+            let middle = path.dropFirst("/api/workspaces/".count).dropLast("/tree".count)
+            handleWorkspaceTree(idString: String(middle), on: connection)
+
+        // Workspaces
+        case ("POST", "/api/workspaces"):
+            handleCreateWorkspace(body: request.body, on: connection)
+        case ("PATCH", let path) where path.hasPrefix("/api/workspaces/"):
+            let idString = String(path.dropFirst("/api/workspaces/".count))
+            handlePatchWorkspace(idString: idString, body: request.body, on: connection)
+
+        // Folders
+        case ("POST", "/api/folders"):
+            handleCreateFolder(body: request.body, on: connection)
+        case ("PATCH", let path) where path.hasPrefix("/api/folders/"):
+            let idString = String(path.dropFirst("/api/folders/".count))
+            handlePatchFolder(idString: idString, body: request.body, on: connection)
+
+        // Links
+        case ("POST", "/api/links"):
+            handleCreateLink(body: request.body, on: connection)
+        case ("PATCH", let path) where path.hasPrefix("/api/links/"):
+            let idString = String(path.dropFirst("/api/links/".count))
+            handlePatchLink(idString: idString, body: request.body, on: connection)
+
+        // Notes — create + metadata patch. Content read/write stays on the
+        // existing GET/PUT routes below, shared with the bundled editor.
+        case ("POST", "/api/notes"):
+            handleCreateNote(body: request.body, on: connection)
+        case ("PATCH", let path) where path.hasPrefix("/api/notes/"):
+            let idString = String(path.dropFirst("/api/notes/".count))
+            handlePatchNote(idString: idString, body: request.body, on: connection)
         case ("GET", let path) where path.hasPrefix("/api/notes/"):
             let idString = String(path.dropFirst("/api/notes/".count))
             handleGetNote(idString: idString, on: connection)
         case ("PUT", let path) where path.hasPrefix("/api/notes/"):
             let idString = String(path.dropFirst("/api/notes/".count))
             handlePutNote(idString: idString, body: request.body, on: connection)
+
+        // Generic node ops
+        case ("DELETE", let path) where path.hasPrefix("/api/nodes/"):
+            let idString = String(path.dropFirst("/api/nodes/".count))
+            handleDeleteNode(idString: idString, on: connection)
+        case ("POST", let path) where path.hasPrefix("/api/nodes/") && path.hasSuffix("/move"):
+            let middle = path.dropFirst("/api/nodes/".count).dropLast("/move".count)
+            handleMoveNode(idString: String(middle), body: request.body, on: connection)
+
         default:
             sendStatus(404, message: "Not Found", on: connection)
         }
     }
 
     private func noteTitle(id: UUID) -> String? {
-        guard let node = model?.nodeById(id) else { return nil }
+        guard let node = model?.nodeAcrossWorkspaces(id: id) else { return nil }
         if case .note(let note) = node { return note.title }
         return nil
     }
@@ -244,6 +291,440 @@ final class NoteServer {
         } catch {
             sendStatus(500, message: "Write Failed", on: connection)
         }
+    }
+
+    // MARK: - Agent API handlers
+
+    private func handleGetState(on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(model.state)
+            sendOkRawJSON(top: ["state": data], on: connection)
+        } catch {
+            sendError(status: 500, code: "encode_failed", message: "Failed to encode state", on: connection)
+        }
+    }
+
+    private func handleListWorkspaces(on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        let list: [[String: Any]] = model.workspaces.map { ws in
+            [
+                "id": ws.id.uuidString,
+                "name": ws.name,
+                "colorId": ws.colorId.rawValue
+            ]
+        }
+        sendOk(["workspaces": list], on: connection)
+    }
+
+    private func handleWorkspaceTree(idString: String, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid workspace id", on: connection)
+            return
+        }
+        guard let workspace = model.workspaces.first(where: { $0.id == id }) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Workspace not found", on: connection)
+            return
+        }
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(workspace)
+            sendOkRawJSON(top: ["workspace": data], on: connection)
+        } catch {
+            sendError(status: 500, code: "encode_failed", message: "Failed to encode workspace", on: connection)
+        }
+    }
+
+    private func handleCreateWorkspace(body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        guard let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+            sendError(status: 400, code: "bad_name", message: "name is required", on: connection)
+            return
+        }
+        let color: WorkspaceColorId
+        if let raw = json["colorId"] as? String {
+            guard let resolved = Self.resolveColor(raw) else {
+                sendError(status: 400, code: "bad_color", message: "Unknown colorId: \(raw)", on: connection)
+                return
+            }
+            color = resolved
+        } else {
+            color = .defaultColor()
+        }
+        let id = model.createWorkspace(name: name, colorId: color)
+        sendOk(["id": id.uuidString], on: connection)
+    }
+
+    private func handlePatchWorkspace(idString: String, body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid workspace id", on: connection)
+            return
+        }
+        guard model.workspaces.contains(where: { $0.id == id }) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Workspace not found", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        if let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            model.renameWorkspace(id: id, newName: name)
+        }
+        if let raw = json["colorId"] as? String {
+            guard let resolved = Self.resolveColor(raw) else {
+                sendError(status: 400, code: "bad_color", message: "Unknown colorId: \(raw)", on: connection)
+                return
+            }
+            model.updateWorkspaceColor(id: id, colorId: resolved)
+        }
+        sendOk([:], on: connection)
+    }
+
+    private func handleCreateFolder(body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        guard let wsId = Self.parseUUID(json["workspace_id"]) else {
+            sendError(status: 400, code: "bad_workspace_id", message: "workspace_id is required", on: connection)
+            return
+        }
+        guard let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else {
+            sendError(status: 400, code: "bad_name", message: "name is required", on: connection)
+            return
+        }
+        let parentId = Self.parseOptionalUUID(json["parent_id"])
+        if let parentResult = validateParent(workspaceId: wsId, parentId: parentId, expectFolder: true) {
+            switch parentResult {
+            case .success: break
+            case .failure(let code, let message):
+                sendError(status: 404, code: code, message: message, on: connection)
+                return
+            }
+        }
+        let expanded = (json["expanded"] as? Bool) ?? true
+        guard let id = model.addFolder(name: name, workspaceId: wsId, parentId: parentId, isExpanded: expanded) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Workspace not found", on: connection)
+            return
+        }
+        sendOk(["id": id.uuidString], on: connection)
+    }
+
+    private func handlePatchFolder(idString: String, body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid id", on: connection)
+            return
+        }
+        guard let node = model.nodeAcrossWorkspaces(id: id), case .folder = node else {
+            sendError(status: 404, code: "folder_not_found", message: "Folder not found", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        if let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
+            model.renameNode(id: id, newName: name)
+        }
+        if let expanded = json["expanded"] as? Bool {
+            model.setFolderExpanded(id: id, isExpanded: expanded)
+        }
+        sendOk([:], on: connection)
+    }
+
+    private func handleCreateLink(body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        guard let wsId = Self.parseUUID(json["workspace_id"]) else {
+            sendError(status: 400, code: "bad_workspace_id", message: "workspace_id is required", on: connection)
+            return
+        }
+        guard let url = (json["url"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !url.isEmpty else {
+            sendError(status: 400, code: "bad_url", message: "url is required", on: connection)
+            return
+        }
+        let parentId = Self.parseOptionalUUID(json["parent_id"])
+        if let result = validateParent(workspaceId: wsId, parentId: parentId, expectFolder: true) {
+            switch result {
+            case .success: break
+            case .failure(let code, let message):
+                sendError(status: 404, code: code, message: message, on: connection)
+                return
+            }
+        }
+        let providedTitle = (json["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title: String
+        if let providedTitle, !providedTitle.isEmpty {
+            title = providedTitle
+        } else {
+            title = URL(string: url)?.host ?? url
+        }
+        guard let id = model.addLink(urlString: url, title: title, workspaceId: wsId, parentId: parentId) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Workspace not found", on: connection)
+            return
+        }
+        sendOk(["id": id.uuidString], on: connection)
+    }
+
+    private func handlePatchLink(idString: String, body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid id", on: connection)
+            return
+        }
+        guard let node = model.nodeAcrossWorkspaces(id: id), case .link = node else {
+            sendError(status: 404, code: "link_not_found", message: "Link not found", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        if let title = (json["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+            model.renameNode(id: id, newName: title)
+        }
+        if let url = (json["url"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !url.isEmpty {
+            model.updateLinkUrl(id: id, newUrl: url)
+        }
+        sendOk([:], on: connection)
+    }
+
+    private func handleCreateNote(body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        guard let wsId = Self.parseUUID(json["workspace_id"]) else {
+            sendError(status: 400, code: "bad_workspace_id", message: "workspace_id is required", on: connection)
+            return
+        }
+        guard let title = (json["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else {
+            sendError(status: 400, code: "bad_title", message: "title is required", on: connection)
+            return
+        }
+        let parentId = Self.parseOptionalUUID(json["parent_id"])
+        if let result = validateParent(workspaceId: wsId, parentId: parentId, expectFolder: true) {
+            switch result {
+            case .success: break
+            case .failure(let code, let message):
+                sendError(status: 404, code: code, message: message, on: connection)
+                return
+            }
+        }
+        let content = (json["content"] as? String) ?? ""
+        guard let id = model.addNote(title: title, workspaceId: wsId, parentId: parentId, content: content) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Workspace not found", on: connection)
+            return
+        }
+        sendOk(["id": id.uuidString], on: connection)
+    }
+
+    private func handlePatchNote(idString: String, body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid id", on: connection)
+            return
+        }
+        guard let node = model.nodeAcrossWorkspaces(id: id), case .note = node else {
+            sendError(status: 404, code: "note_not_found", message: "Note not found", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        if let title = (json["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty {
+            model.renameNode(id: id, newName: title)
+        }
+        sendOk([:], on: connection)
+    }
+
+    private func handleDeleteNode(idString: String, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid id", on: connection)
+            return
+        }
+        guard model.nodeAcrossWorkspaces(id: id) != nil else {
+            sendError(status: 404, code: "node_not_found", message: "Node not found", on: connection)
+            return
+        }
+        model.deleteNode(id: id)
+        sendOk([:], on: connection)
+    }
+
+    private func handleMoveNode(idString: String, body: Data, on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        guard let id = UUID(uuidString: idString) else {
+            sendError(status: 400, code: "bad_id", message: "Invalid id", on: connection)
+            return
+        }
+        guard let sourceWsId = model.workspaceId(forNodeId: id) else {
+            sendError(status: 404, code: "node_not_found", message: "Node not found", on: connection)
+            return
+        }
+        guard let json = parseJSONObject(body) else {
+            sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
+            return
+        }
+        let toWsId = Self.parseOptionalUUID(json["to_workspace_id"])
+        let toParentId = Self.parseOptionalUUID(json["to_parent_id"])
+        let index = json["index"] as? Int
+
+        let destWsId = toWsId ?? sourceWsId
+        guard model.workspaces.contains(where: { $0.id == destWsId }) else {
+            sendError(status: 404, code: "workspace_not_found", message: "Destination workspace not found", on: connection)
+            return
+        }
+        if let toParentId {
+            guard let parentNode = model.nodeAcrossWorkspaces(id: toParentId), case .folder = parentNode else {
+                sendError(status: 404, code: "parent_not_found", message: "Target parent folder not found", on: connection)
+                return
+            }
+            if model.workspaceId(forNodeId: toParentId) != destWsId {
+                sendError(status: 400, code: "parent_wrong_workspace", message: "Target parent is in a different workspace", on: connection)
+                return
+            }
+        }
+
+        if destWsId == sourceWsId {
+            model.moveNode(id: id, toParentId: toParentId, index: index ?? Int.max)
+        } else {
+            model.moveNodeToWorkspace(id: id, workspaceId: destWsId, parentId: toParentId, index: index)
+        }
+        sendOk([:], on: connection)
+    }
+
+    // MARK: - Agent API helpers
+
+    private enum ParentValidation {
+        case success
+        case failure(code: String, message: String)
+    }
+
+    private func validateParent(workspaceId: UUID, parentId: UUID?, expectFolder: Bool) -> ParentValidation? {
+        guard let parentId else { return nil }
+        guard let model else { return .failure(code: "model_unavailable", message: "App model not available") }
+        guard let workspace = model.workspaces.first(where: { $0.id == workspaceId }) else {
+            return .failure(code: "workspace_not_found", message: "Workspace not found")
+        }
+        guard let node = model.findNode(id: parentId, in: workspace.items) else {
+            return .failure(code: "parent_not_found", message: "Parent folder not found in workspace")
+        }
+        if expectFolder, case .folder = node { return .success }
+        if expectFolder { return .failure(code: "parent_not_folder", message: "parent_id must reference a folder") }
+        return .success
+    }
+
+    private func parseJSONObject(_ data: Data) -> [String: Any]? {
+        if data.isEmpty { return [:] }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+
+    private static func parseUUID(_ value: Any?) -> UUID? {
+        guard let s = value as? String else { return nil }
+        return UUID(uuidString: s)
+    }
+
+    private static func parseOptionalUUID(_ value: Any?) -> UUID? {
+        guard let s = value as? String, !s.isEmpty else { return nil }
+        return UUID(uuidString: s)
+    }
+
+    private static func resolveColor(_ raw: String) -> WorkspaceColorId? {
+        let trimmed = raw.trimmingCharacters(in: .whitespaces)
+        if let direct = WorkspaceColorId(rawValue: trimmed) {
+            return direct == .settingsBackground ? nil : direct
+        }
+        let lower = trimmed.lowercased()
+        for case let c in WorkspaceColorId.allCases where c.name.lowercased() == lower {
+            return c
+        }
+        return nil
+    }
+
+    private func sendOk(_ payload: [String: Any], on connection: NWConnection) {
+        var dict = payload
+        dict["ok"] = true
+        sendJSON(dict, on: connection)
+    }
+
+    private func sendOkRawJSON(top: [String: Data], on connection: NWConnection) {
+        // Builds `{"ok":true,"<key>":<rawJson>,...}` so we can splice in
+        // pre-encoded JSON (e.g. AppState) without lossy round-tripping.
+        var parts: [String] = ["\"ok\":true"]
+        for (key, data) in top {
+            let escapedKey = key.replacingOccurrences(of: "\"", with: "\\\"")
+            let json = String(data: data, encoding: .utf8) ?? "null"
+            parts.append("\"\(escapedKey)\":\(json)")
+        }
+        let body = Data("{\(parts.joined(separator: ","))}".utf8)
+        sendResponse(status: 200, statusMessage: "OK", contentType: "application/json; charset=utf-8", body: body, on: connection)
+    }
+
+    private func sendError(status: Int, code: String, message: String, on connection: NWConnection) {
+        let payload: [String: Any] = [
+            "ok": false,
+            "error": message,
+            "code": code
+        ]
+        let data = (try? JSONSerialization.data(withJSONObject: payload)) ?? Data("{\"ok\":false}".utf8)
+        sendResponse(status: status, statusMessage: "Error", contentType: "application/json; charset=utf-8", body: data, on: connection)
     }
 
     // MARK: - Static asset serving

--- a/Sources/ArcmarkCore/Notes/NoteServer.swift
+++ b/Sources/ArcmarkCore/Notes/NoteServer.swift
@@ -194,6 +194,8 @@ final class NoteServer {
             handleGetState(on: connection)
         case ("GET", "/api/workspaces"):
             handleListWorkspaces(on: connection)
+        case ("GET", "/api/workspaces/current"):
+            handleCurrentWorkspace(on: connection)
         case ("GET", let path) where path.hasPrefix("/api/workspaces/") && path.hasSuffix("/tree"):
             let middle = path.dropFirst("/api/workspaces/".count).dropLast("/tree".count)
             handleWorkspaceTree(idString: String(middle), on: connection)
@@ -323,6 +325,37 @@ final class NoteServer {
             ]
         }
         sendOk(["workspaces": list], on: connection)
+    }
+
+    private func handleCurrentWorkspace(on connection: NWConnection) {
+        guard let model else {
+            sendError(status: 503, code: "model_unavailable", message: "App model not available", on: connection)
+            return
+        }
+        let state = model.state
+        let selectedId = state.selectedWorkspaceId
+        let workspace = selectedId.flatMap { id in model.workspaces.first(where: { $0.id == id }) }
+
+        if let workspace {
+            let payload: [String: Any] = [
+                "selected": true,
+                "settingsSelected": state.isSettingsSelected,
+                "workspace": [
+                    "id": workspace.id.uuidString,
+                    "name": workspace.name,
+                    "colorId": workspace.colorId.rawValue
+                ]
+            ]
+            sendOk(payload, on: connection)
+            return
+        }
+
+        let payload: [String: Any] = [
+            "selected": false,
+            "settingsSelected": state.isSettingsSelected,
+            "workspace": NSNull()
+        ]
+        sendOk(payload, on: connection)
     }
 
     private func handleWorkspaceTree(idString: String, on connection: NWConnection) {

--- a/Sources/ArcmarkCore/Notes/NoteServer.swift
+++ b/Sources/ArcmarkCore/Notes/NoteServer.swift
@@ -392,15 +392,27 @@ final class NoteServer {
             sendError(status: 400, code: "bad_body", message: "Body must be a JSON object", on: connection)
             return
         }
-        if let name = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty {
-            model.renameWorkspace(id: id, newName: name)
-        }
+        // Resolve all fields before mutating so a bad colorId can't leave
+        // a partial rename applied.
+        let trimmedName = (json["name"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let newName: String? = (trimmedName?.isEmpty == false) ? trimmedName : nil
+
+        let newColor: WorkspaceColorId?
         if let raw = json["colorId"] as? String {
             guard let resolved = Self.resolveColor(raw) else {
                 sendError(status: 400, code: "bad_color", message: "Unknown colorId: \(raw)", on: connection)
                 return
             }
-            model.updateWorkspaceColor(id: id, colorId: resolved)
+            newColor = resolved
+        } else {
+            newColor = nil
+        }
+
+        if let newName {
+            model.renameWorkspace(id: id, newName: newName)
+        }
+        if let newColor {
+            model.updateWorkspaceColor(id: id, colorId: newColor)
         }
         sendOk([:], on: connection)
     }

--- a/Sources/ArcmarkCore/Notes/NoteServer.swift
+++ b/Sources/ArcmarkCore/Notes/NoteServer.swift
@@ -626,6 +626,11 @@ final class NoteServer {
         let toParentId = Self.parseOptionalUUID(json["to_parent_id"])
         let index = json["index"] as? Int
 
+        if json["to_workspace_id"] == nil, json["to_parent_id"] == nil, json["index"] == nil {
+            sendError(status: 400, code: "no_move_params", message: "Provide at least one of to_workspace_id, to_parent_id, or index", on: connection)
+            return
+        }
+
         let destWsId = toWsId ?? sourceWsId
         guard model.workspaces.contains(where: { $0.id == destWsId }) else {
             sendError(status: 404, code: "workspace_not_found", message: "Destination workspace not found", on: connection)

--- a/Tests/ArcmarkTests/NoteServerTests.swift
+++ b/Tests/ArcmarkTests/NoteServerTests.swift
@@ -316,6 +316,32 @@ final class NoteServerTests: XCTestCase {
         XCTAssertNotNil(treeJson["workspace"])
     }
 
+    func testCurrentWorkspaceReturnsSelected() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id)
+        model.selectWorkspace(id: wsId)
+
+        let (status, json) = try await apiRequest("GET", "/api/workspaces/current", port: server.port)
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(json["selected"] as? Bool, true)
+        XCTAssertEqual(json["settingsSelected"] as? Bool, false)
+        let workspace = try XCTUnwrap(json["workspace"] as? [String: Any])
+        XCTAssertEqual(workspace["id"] as? String, wsId.uuidString)
+    }
+
+    func testCurrentWorkspaceReportsSettings() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        model.selectSettings()
+
+        let (status, json) = try await apiRequest("GET", "/api/workspaces/current", port: server.port)
+        XCTAssertEqual(status, 200)
+        XCTAssertEqual(json["selected"] as? Bool, false)
+        XCTAssertEqual(json["settingsSelected"] as? Bool, true)
+        XCTAssertTrue(json["workspace"] is NSNull)
+    }
+
     func testCreateWorkspaceRejectsUnknownColor() async throws {
         // Bind `model` so NoteServer's weak reference stays alive.
         let (server, model) = try await startServer()

--- a/Tests/ArcmarkTests/NoteServerTests.swift
+++ b/Tests/ArcmarkTests/NoteServerTests.swift
@@ -115,4 +115,229 @@ final class NoteServerTests: XCTestCase {
         XCTAssertEqual(status, 200)
         XCTAssertEqual(model.noteStorage.read(id: noteId), "## Updated")
     }
+
+    // MARK: - Agent API round-trips
+
+    private func apiRequest(
+        _ method: String,
+        _ path: String,
+        body: [String: Any]? = nil,
+        port: UInt16
+    ) async throws -> (status: Int, json: [String: Any]) {
+        let data = body.map { try? JSONSerialization.data(withJSONObject: $0) } ?? nil
+        let (status, raw) = try await request(method: method, path: path, body: data ?? nil, port: port)
+        let parsed = (try? JSONSerialization.jsonObject(with: raw)) as? [String: Any] ?? [:]
+        return (status, parsed)
+    }
+
+    func testWorkspaceRoundTrip() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+
+        let (createStatus, createJson) = try await apiRequest(
+            "POST", "/api/workspaces",
+            body: ["name": "Reading", "colorId": "leaf"],
+            port: server.port
+        )
+        XCTAssertEqual(createStatus, 200)
+        XCTAssertEqual(createJson["ok"] as? Bool, true)
+        let id = try XCTUnwrap(createJson["id"] as? String)
+        let uuid = try XCTUnwrap(UUID(uuidString: id))
+        XCTAssertTrue(model.workspaces.contains(where: { $0.id == uuid }))
+
+        let (renameStatus, _) = try await apiRequest(
+            "PATCH", "/api/workspaces/\(id)",
+            body: ["name": "Reading List"],
+            port: server.port
+        )
+        XCTAssertEqual(renameStatus, 200)
+        XCTAssertEqual(model.workspaces.first(where: { $0.id == uuid })?.name, "Reading List")
+    }
+
+    func testFolderRoundTrip() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+
+        let (createStatus, createJson) = try await apiRequest(
+            "POST", "/api/folders",
+            body: ["workspace_id": wsId, "name": "Inbox"],
+            port: server.port
+        )
+        XCTAssertEqual(createStatus, 200)
+        let id = try XCTUnwrap(createJson["id"] as? String)
+        let uuid = try XCTUnwrap(UUID(uuidString: id))
+
+        let node = try XCTUnwrap(model.nodeAcrossWorkspaces(id: uuid))
+        guard case .folder(let folder) = node else { return XCTFail("Expected folder") }
+        XCTAssertEqual(folder.name, "Inbox")
+
+        let (renameStatus, _) = try await apiRequest(
+            "PATCH", "/api/folders/\(id)",
+            body: ["name": "Triage", "expanded": false],
+            port: server.port
+        )
+        XCTAssertEqual(renameStatus, 200)
+        if case .folder(let updated) = try XCTUnwrap(model.nodeAcrossWorkspaces(id: uuid)) {
+            XCTAssertEqual(updated.name, "Triage")
+            XCTAssertFalse(updated.isExpanded)
+        } else {
+            XCTFail("Expected folder after rename")
+        }
+    }
+
+    func testLinkRoundTrip() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+
+        let (status, createJson) = try await apiRequest(
+            "POST", "/api/links",
+            body: ["workspace_id": wsId, "url": "https://anthropic.com", "title": "Anthropic"],
+            port: server.port
+        )
+        XCTAssertEqual(status, 200)
+        let id = try XCTUnwrap(createJson["id"] as? String)
+        let uuid = try XCTUnwrap(UUID(uuidString: id))
+        guard case .link(let link) = try XCTUnwrap(model.nodeAcrossWorkspaces(id: uuid)) else {
+            return XCTFail("Expected link")
+        }
+        XCTAssertEqual(link.url, "https://anthropic.com")
+        XCTAssertEqual(link.title, "Anthropic")
+
+        let (patchStatus, _) = try await apiRequest(
+            "PATCH", "/api/links/\(id)",
+            body: ["title": "Anthropic AI", "url": "https://www.anthropic.com"],
+            port: server.port
+        )
+        XCTAssertEqual(patchStatus, 200)
+        if case .link(let updated) = try XCTUnwrap(model.nodeAcrossWorkspaces(id: uuid)) {
+            XCTAssertEqual(updated.title, "Anthropic AI")
+            XCTAssertEqual(updated.url, "https://www.anthropic.com")
+        } else {
+            XCTFail("Expected link after patch")
+        }
+    }
+
+    func testNoteRoundTrip() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+
+        let (status, createJson) = try await apiRequest(
+            "POST", "/api/notes",
+            body: ["workspace_id": wsId, "title": "Plan", "content": "# Hello"],
+            port: server.port
+        )
+        XCTAssertEqual(status, 200)
+        let id = try XCTUnwrap(createJson["id"] as? String)
+        let uuid = try XCTUnwrap(UUID(uuidString: id))
+        XCTAssertEqual(model.noteStorage.read(id: uuid), "# Hello")
+
+        let (renameStatus, _) = try await apiRequest(
+            "PATCH", "/api/notes/\(id)",
+            body: ["title": "Renamed"],
+            port: server.port
+        )
+        XCTAssertEqual(renameStatus, 200)
+        if case .note(let note) = try XCTUnwrap(model.nodeAcrossWorkspaces(id: uuid)) {
+            XCTAssertEqual(note.title, "Renamed")
+        } else {
+            XCTFail("Expected note after patch")
+        }
+    }
+
+    func testMoveAcrossWorkspaces() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let sourceWsId = try XCTUnwrap(model.workspaces.first?.id)
+        let destWsId = model.createWorkspace(name: "Other", colorId: .moss)
+
+        // Note: createWorkspace also flips selectedWorkspaceId. Re-select source
+        // so addLink without explicit workspaceId would still go there if used,
+        // but we use the explicit workspaceId variant via the API for safety.
+        model.selectWorkspace(id: sourceWsId)
+
+        let (_, createJson) = try await apiRequest(
+            "POST", "/api/links",
+            body: ["workspace_id": sourceWsId.uuidString, "url": "https://example.com"],
+            port: server.port
+        )
+        let linkId = try XCTUnwrap(createJson["id"] as? String)
+        let linkUUID = try XCTUnwrap(UUID(uuidString: linkId))
+
+        let (moveStatus, moveJson) = try await apiRequest(
+            "POST", "/api/nodes/\(linkId)/move",
+            body: ["to_workspace_id": destWsId.uuidString],
+            port: server.port
+        )
+        XCTAssertEqual(moveStatus, 200)
+        XCTAssertEqual(moveJson["ok"] as? Bool, true)
+
+        XCTAssertEqual(model.workspaceId(forNodeId: linkUUID), destWsId)
+    }
+
+    func testDeleteNode() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+
+        let (_, createJson) = try await apiRequest(
+            "POST", "/api/notes",
+            body: ["workspace_id": wsId, "title": "Doomed", "content": "bye"],
+            port: server.port
+        )
+        let id = try XCTUnwrap(createJson["id"] as? String)
+        let uuid = try XCTUnwrap(UUID(uuidString: id))
+        XCTAssertNotNil(model.nodeAcrossWorkspaces(id: uuid))
+
+        let (status, _) = try await apiRequest(
+            "DELETE", "/api/nodes/\(id)",
+            port: server.port
+        )
+        XCTAssertEqual(status, 200)
+        XCTAssertNil(model.nodeAcrossWorkspaces(id: uuid))
+        // The note .md file is cleaned up by deleteNode.
+        XCTAssertEqual(model.noteStorage.read(id: uuid), "")
+    }
+
+    func testStateAndTreeEndpoints() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+
+        let (stateStatus, stateJson) = try await apiRequest("GET", "/api/state", port: server.port)
+        XCTAssertEqual(stateStatus, 200)
+        XCTAssertEqual(stateJson["ok"] as? Bool, true)
+        XCTAssertNotNil(stateJson["state"])
+
+        let (treeStatus, treeJson) = try await apiRequest("GET", "/api/workspaces/\(wsId)/tree", port: server.port)
+        XCTAssertEqual(treeStatus, 200)
+        XCTAssertNotNil(treeJson["workspace"])
+    }
+
+    func testCreateWorkspaceRejectsUnknownColor() async throws {
+        // Bind `model` so NoteServer's weak reference stays alive.
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        _ = model
+        let (status, json) = try await apiRequest(
+            "POST", "/api/workspaces",
+            body: ["name": "X", "colorId": "puce"],
+            port: server.port
+        )
+        XCTAssertEqual(status, 400)
+        XCTAssertEqual(json["code"] as? String, "bad_color")
+    }
+
+    func testNoDeleteWorkspaceRoute() async throws {
+        let (server, model) = try await startServer()
+        defer { server.stop() }
+        let wsId = try XCTUnwrap(model.workspaces.first?.id).uuidString
+        let (status, _) = try await apiRequest(
+            "DELETE", "/api/workspaces/\(wsId)",
+            port: server.port
+        )
+        XCTAssertEqual(status, 404)
+    }
 }

--- a/skills/arcmark/CHANGELOG.md
+++ b/skills/arcmark/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2026-05-18
+
+- Initial release. Adds the `arcmark` skill and the `arcmark.js` CLI for
+  organizing bookmarks, folders, and markdown notes inside the running
+  Arcmark macOS app. Talks to the loopback HTTP server exposed by the
+  app and discovered via `~/Library/Application Support/Arcmark/agent-endpoint.json`.

--- a/skills/arcmark/SKILL.md
+++ b/skills/arcmark/SKILL.md
@@ -42,6 +42,7 @@ file editing.
 
 | User phrasing | Command |
 |---|---|
+| "Save this here" / "Add this to the workspace I'm in" | `workspaces:current` to get the id, then `links:create --workspace WS_ID --url URL` |
 | "Save this link in my Reading workspace" | `links:create --workspace WS_ID --url URL` |
 | "Add a folder called Reading" | `folders:create --workspace WS_ID --name "Reading"` |
 | "Group these tabs into a Research folder in my Reading workspace" | create folder, then `nodes:move` each link with `--to-parent FOLDER_ID` |
@@ -58,6 +59,11 @@ file editing.
 1. **Find ids first.** Run `arcmark.js state` (or `arcmark.js workspaces:list`
    plus `arcmark.js tree WORKSPACE_ID`) to discover the workspace, folder,
    and node UUIDs you need. Never invent or guess ids.
+   - When the user says "this workspace", "the current one", "the one I'm
+     in", or "here", resolve it with `arcmark.js workspaces:current`. The
+     response is `{ selected, settingsSelected, workspace: { id, name, colorId } | null }`.
+     If `selected` is false (e.g. the user is on the Settings screen),
+     ask which workspace to use instead of guessing.
 2. **Decide on a target.** Pick which workspace and (optionally) parent
    folder a new node should live in. If the user is ambiguous, ask.
 3. **Compose atomic mutations.** Run one CLI command per action. Each
@@ -124,6 +130,7 @@ state                                  Dump the full AppState JSON.
 tree WORKSPACE_ID                      Dump one workspace's tree.
 
 workspaces:list
+workspaces:current                       Workspace currently visible in the app.
 workspaces:create        --name "X" [--color NAME]
 workspaces:rename ID     --name "Y"
 workspaces:set-color ID  --color NAME

--- a/skills/arcmark/SKILL.md
+++ b/skills/arcmark/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: arcmark
+description: >
+  Organize bookmarks, folders, and markdown notes in the Arcmark macOS app.
+  ALWAYS use this skill when the user asks to save a link, create a folder,
+  move bookmarks between workspaces, take notes, or otherwise tidy their
+  Arcmark sidebar.
+last-updated: 2026-05-18
+allowed-tools: Bash(./scripts/arcmark.js:*)
+---
+
+# Arcmark Agent Skill
+
+Arcmark is a macOS sidebar app for organizing bookmarks and short markdown
+notes inside named, color-coded **workspaces**. This skill lets you create
+and rearrange that content on the user's behalf — atomically, with no manual
+file editing.
+
+## Setup / prerequisites
+
+- **Arcmark must be running.** All commands talk to a local HTTP server inside
+  the running app.
+- If a command exits with `code: "app_not_running"`, **stop and ask the user
+  to launch Arcmark.app** before retrying. Do not loop on retries.
+- You do not need network access; everything is on `127.0.0.1`.
+
+## Glossary
+
+- **Workspace** — a named, colored top-level container (e.g. "Reading",
+  "Work"). Workspaces hold nodes. The agent can create and rename them, but
+  **cannot delete workspaces** — this is a hard rule.
+- **Folder** — a named container that can hold links, notes, and other
+  folders. Nestable.
+- **Link** — a bookmark with a title and a URL. The app fetches favicons
+  automatically.
+- **Note** — a markdown document with a title and a body. Body content is
+  stored as a `.md` file and read/written with `notes:read` and `notes:write`.
+- **Node** — any of folder, link, or note. Generic operations like
+  `nodes:move` work on all three.
+
+## Common Actions
+
+| User phrasing | Command |
+|---|---|
+| "Save this link in my Reading workspace" | `links:create --workspace WS_ID --url URL` |
+| "Add a folder called Reading" | `folders:create --workspace WS_ID --name "Reading"` |
+| "Group these tabs into a Research folder in my Reading workspace" | create folder, then `nodes:move` each link with `--to-parent FOLDER_ID` |
+| "Move this link to my Work workspace" | `nodes:move LINK_ID --to-workspace WORK_WS_ID` |
+| "Rename this folder to Inbox" | `folders:rename FOLDER_ID --name "Inbox"` |
+| "Take a note titled Plan" | `notes:create --workspace WS_ID --title "Plan"` |
+| "Write up this meeting in a note" | `notes:create ... --content -` then pipe markdown to stdin |
+| "What's in my Reading workspace?" | `tree WS_ID` |
+| "Make a new workspace called Research" | `workspaces:create --name "Research"` |
+| "Delete this bookmark" | `nodes:delete NODE_ID` (or `links:delete`) |
+
+## Workflow
+
+1. **Find ids first.** Run `arcmark.js state` (or `arcmark.js workspaces:list`
+   plus `arcmark.js tree WORKSPACE_ID`) to discover the workspace, folder,
+   and node UUIDs you need. Never invent or guess ids.
+2. **Decide on a target.** Pick which workspace and (optionally) parent
+   folder a new node should live in. If the user is ambiguous, ask.
+3. **Compose atomic mutations.** Run one CLI command per action. Each
+   command is a single API call; the running app updates the sidebar
+   immediately.
+4. **Confirm before destructive bulk work.** Before deleting multiple
+   nodes — especially folders containing many children — confirm with the
+   user. Deletes are not undoable from the CLI.
+
+## Writing note bodies
+
+Three ways to supply note content, in order of preference for long
+documents:
+
+- `--content -` reads the body from stdin. Use this when piping or
+  here-docs:
+
+  ```bash
+  ./scripts/arcmark.js notes:write NOTE_ID --content - <<'EOF'
+  # Heading
+  Paragraph with **markdown**.
+  EOF
+  ```
+
+- `--file path/to/file.md` reads a file from disk.
+
+- `--content "..."` for short snippets that fit on a single command line.
+
+`notes:read NOTE_ID` prints the body to stdout so you can fetch existing
+content before editing.
+
+## Moving across workspaces
+
+`nodes:move` is the universal mover. It accepts:
+
+- `--to-workspace ID` — moves to a different workspace. Omit to move within
+  the current workspace.
+- `--to-parent ID` — drops the node inside that folder. Pass the literal
+  `root` to move to the workspace root.
+- `--index N` — position within the parent (0-based). Omit to append.
+
+Combinations:
+
+- Same workspace, reorder: `nodes:move ID --to-parent FOLDER_ID --index 0`
+- Cross workspace, into a folder: `nodes:move ID --to-workspace WS --to-parent FOLDER_ID`
+- Cross workspace, to root: `nodes:move ID --to-workspace WS --to-parent root`
+
+## Rules and limits
+
+- **Never delete a workspace.** There is no command for it; do not try.
+  If the user explicitly asks, explain that workspaces must be removed
+  manually from the app.
+- Workspace **color names**: Blush, Apricot, Butter, Leaf, Mint, Sky,
+  Periwinkle, Lavender. Case-insensitive; raw enum cases (ember, ruby,
+  coral, tangerine, moss, ocean, indigo, graphite) also work.
+- Every command exits non-zero on failure and prints `{ error, code, ... }`
+  to stderr. Inspect `code` — `app_not_running`, `workspace_not_found`,
+  `parent_not_folder`, `node_not_found` are the common ones.
+
+## Commands Reference
+
+```
+state                                  Dump the full AppState JSON.
+tree WORKSPACE_ID                      Dump one workspace's tree.
+
+workspaces:list
+workspaces:create        --name "X" [--color NAME]
+workspaces:rename ID     --name "Y"
+workspaces:set-color ID  --color NAME
+
+folders:create   --workspace ID [--parent ID|root] --name "X" [--expanded true|false]
+folders:rename   ID  --name "Y"
+folders:delete   ID
+
+links:create     --workspace ID [--parent ID|root] --url URL [--title T]
+links:rename     ID  --title "Y"
+links:set-url    ID  --url URL
+links:delete     ID
+
+notes:create     --workspace ID [--parent ID|root] --title T [--content TEXT | --file PATH | --content -]
+notes:rename     ID  --title "Y"
+notes:read       ID
+notes:write      ID  --content TEXT | --file PATH | --content -
+notes:delete     ID
+
+nodes:move       ID [--to-workspace ID] [--to-parent ID|root] [--index N]
+nodes:delete     ID
+```
+
+## Examples
+
+Group two existing links into a new folder inside the Reading workspace:
+
+```bash
+# 1. Find the ids.
+./scripts/arcmark.js workspaces:list
+# -> [{"id":"...reading...","name":"Reading", ...}]
+
+./scripts/arcmark.js tree READING_WS_ID
+# Pick out the two link ids from the tree output.
+
+# 2. Create the folder.
+FOLDER_ID=$(./scripts/arcmark.js folders:create \
+  --workspace READING_WS_ID --name "Research" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+
+# 3. Move each link into it.
+./scripts/arcmark.js nodes:move LINK_ID_1 --to-parent "$FOLDER_ID"
+./scripts/arcmark.js nodes:move LINK_ID_2 --to-parent "$FOLDER_ID"
+```
+
+Create a note in Reading and fill it with markdown from stdin:
+
+```bash
+NOTE_ID=$(./scripts/arcmark.js notes:create \
+  --workspace READING_WS_ID --title "Weekly plan" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+
+./scripts/arcmark.js notes:write "$NOTE_ID" --content - <<'EOF'
+# Weekly plan
+
+- Finish the report
+- Email the team
+EOF
+```
+
+Save a link in Work, then move it to a Reading subfolder:
+
+```bash
+LINK_ID=$(./scripts/arcmark.js links:create \
+  --workspace WORK_WS_ID --url "https://anthropic.com" \
+  | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')
+
+./scripts/arcmark.js nodes:move "$LINK_ID" \
+  --to-workspace READING_WS_ID --to-parent RESEARCH_FOLDER_ID
+```

--- a/skills/arcmark/scripts/arcmark.js
+++ b/skills/arcmark/scripts/arcmark.js
@@ -1,0 +1,443 @@
+#!/usr/bin/env node
+// arcmark.js — zero-dependency CLI for the Arcmark agent skill.
+//
+// Talks to the local HTTP server inside the running Arcmark.app via the
+// endpoint file written to ~/Library/Application Support/Arcmark/agent-endpoint.json.
+// All output is JSON to stdout. Errors print {error,code,...} to stderr and
+// exit non-zero.
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ENDPOINT_FILE = path.join(
+  os.homedir(),
+  'Library',
+  'Application Support',
+  'Arcmark',
+  'agent-endpoint.json'
+);
+
+// ---------- Argument parsing ----------
+
+function parseArgs(argv) {
+  const positional = [];
+  const flags = {};
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i];
+    if (arg === '--') {
+      positional.push(...argv.slice(i + 1));
+      break;
+    }
+    if (arg.startsWith('--')) {
+      const eq = arg.indexOf('=');
+      let key, value;
+      if (eq >= 0) {
+        key = arg.slice(2, eq);
+        value = arg.slice(eq + 1);
+      } else {
+        key = arg.slice(2);
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith('--')) {
+          value = true;
+        } else {
+          value = next;
+          i++;
+        }
+      }
+      flags[normalizeFlag(key)] = value;
+    } else {
+      positional.push(arg);
+    }
+    i++;
+  }
+  return { positional, flags };
+}
+
+function normalizeFlag(name) {
+  return name.replace(/_/g, '-').toLowerCase();
+}
+
+function getFlag(flags, ...names) {
+  for (const name of names) {
+    const k = normalizeFlag(name);
+    if (Object.prototype.hasOwnProperty.call(flags, k)) {
+      return flags[k];
+    }
+  }
+  return undefined;
+}
+
+function requireFlag(flags, name) {
+  const v = getFlag(flags, name);
+  if (v === undefined || v === true) {
+    fail('missing_flag', `Missing required --${name}`);
+  }
+  return v;
+}
+
+// ---------- IO helpers ----------
+
+function readEndpoint() {
+  let raw;
+  try {
+    raw = fs.readFileSync(ENDPOINT_FILE, 'utf8');
+  } catch (e) {
+    fail(
+      'app_not_running',
+      'Arcmark does not appear to be running. Ask the user to launch Arcmark.app, then retry.',
+      { endpointFile: ENDPOINT_FILE }
+    );
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    fail('endpoint_corrupt', 'agent-endpoint.json is not valid JSON', { endpointFile: ENDPOINT_FILE });
+  }
+  if (!parsed || typeof parsed.port !== 'number') {
+    fail('endpoint_corrupt', 'agent-endpoint.json missing port', { endpointFile: ENDPOINT_FILE });
+  }
+  return { host: parsed.host || '127.0.0.1', port: parsed.port };
+}
+
+async function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { data += chunk; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+function printJSON(obj) {
+  process.stdout.write(JSON.stringify(obj, null, 2) + '\n');
+}
+
+function fail(code, message, extra = {}) {
+  const payload = { error: message, code, ...extra };
+  process.stderr.write(JSON.stringify(payload, null, 2) + '\n');
+  process.exit(1);
+}
+
+// ---------- HTTP ----------
+
+async function request(method, route, body) {
+  const { host, port } = readEndpoint();
+  const url = `http://${host}:${port}${route}`;
+  const init = { method, headers: {} };
+  if (body !== undefined) {
+    init.headers['Content-Type'] = 'application/json';
+    init.body = typeof body === 'string' ? body : JSON.stringify(body);
+  }
+  let res;
+  try {
+    res = await fetch(url, init);
+  } catch (e) {
+    fail('http_failed', `Could not reach Arcmark at ${url}: ${e.message}`);
+  }
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch (e) {
+    fail('bad_response', `Non-JSON response from ${url}`, { status: res.status, body: text });
+  }
+  if (!res.ok || json.ok === false) {
+    fail(json.code || 'http_error', json.error || `HTTP ${res.status}`, {
+      status: res.status,
+    });
+  }
+  return json;
+}
+
+// ---------- Command handlers ----------
+
+const COMMANDS = {
+  'help': cmdHelp,
+
+  'state': cmdState,
+  'tree': cmdTree,
+
+  'workspaces:list': cmdWorkspacesList,
+  'workspaces:create': cmdWorkspacesCreate,
+  'workspaces:rename': cmdWorkspacesRename,
+  'workspaces:set-color': cmdWorkspacesSetColor,
+
+  'folders:create': cmdFoldersCreate,
+  'folders:rename': cmdFoldersRename,
+  'folders:delete': cmdNodesDelete,
+
+  'links:create': cmdLinksCreate,
+  'links:rename': cmdLinksRename,
+  'links:set-url': cmdLinksSetUrl,
+  'links:delete': cmdNodesDelete,
+
+  'notes:create': cmdNotesCreate,
+  'notes:rename': cmdNotesRename,
+  'notes:read': cmdNotesRead,
+  'notes:write': cmdNotesWrite,
+  'notes:delete': cmdNodesDelete,
+
+  'nodes:move': cmdNodesMove,
+  'nodes:delete': cmdNodesDelete,
+};
+
+async function cmdState() {
+  const out = await request('GET', '/api/state');
+  printJSON(out.state || out);
+}
+
+async function cmdTree(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: tree WORKSPACE_ID');
+  const out = await request('GET', `/api/workspaces/${id}/tree`);
+  printJSON(out.workspace || out);
+}
+
+async function cmdWorkspacesList() {
+  const out = await request('GET', '/api/workspaces');
+  printJSON(out.workspaces || []);
+}
+
+async function cmdWorkspacesCreate(args) {
+  const name = requireFlag(args.flags, 'name');
+  const body = { name };
+  const color = getFlag(args.flags, 'color');
+  if (color !== undefined && color !== true) body.colorId = color;
+  const out = await request('POST', '/api/workspaces', body);
+  printJSON({ id: out.id });
+}
+
+async function cmdWorkspacesRename(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: workspaces:rename ID --name "Y"');
+  const name = requireFlag(args.flags, 'name');
+  await request('PATCH', `/api/workspaces/${id}`, { name });
+  printJSON({ ok: true });
+}
+
+async function cmdWorkspacesSetColor(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: workspaces:set-color ID --color NAME');
+  const color = requireFlag(args.flags, 'color');
+  await request('PATCH', `/api/workspaces/${id}`, { colorId: color });
+  printJSON({ ok: true });
+}
+
+async function cmdFoldersCreate(args) {
+  const workspaceId = requireFlag(args.flags, 'workspace');
+  const name = requireFlag(args.flags, 'name');
+  const body = { workspace_id: workspaceId, name };
+  const parent = getFlag(args.flags, 'parent');
+  if (parent !== undefined && parent !== true && parent !== 'root') {
+    body.parent_id = parent;
+  }
+  const expanded = getFlag(args.flags, 'expanded');
+  if (expanded !== undefined) body.expanded = expanded === true || expanded === 'true';
+  const out = await request('POST', '/api/folders', body);
+  printJSON({ id: out.id });
+}
+
+async function cmdFoldersRename(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: folders:rename ID --name "Y"');
+  const name = requireFlag(args.flags, 'name');
+  await request('PATCH', `/api/folders/${id}`, { name });
+  printJSON({ ok: true });
+}
+
+async function cmdLinksCreate(args) {
+  const workspaceId = requireFlag(args.flags, 'workspace');
+  const url = requireFlag(args.flags, 'url');
+  const body = { workspace_id: workspaceId, url };
+  const parent = getFlag(args.flags, 'parent');
+  if (parent !== undefined && parent !== true && parent !== 'root') {
+    body.parent_id = parent;
+  }
+  const title = getFlag(args.flags, 'title');
+  if (title !== undefined && title !== true) body.title = title;
+  const out = await request('POST', '/api/links', body);
+  printJSON({ id: out.id });
+}
+
+async function cmdLinksRename(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: links:rename ID --title "Y"');
+  const title = requireFlag(args.flags, 'title');
+  await request('PATCH', `/api/links/${id}`, { title });
+  printJSON({ ok: true });
+}
+
+async function cmdLinksSetUrl(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: links:set-url ID --url URL');
+  const url = requireFlag(args.flags, 'url');
+  await request('PATCH', `/api/links/${id}`, { url });
+  printJSON({ ok: true });
+}
+
+async function cmdNotesCreate(args) {
+  const workspaceId = requireFlag(args.flags, 'workspace');
+  const title = requireFlag(args.flags, 'title');
+  const body = { workspace_id: workspaceId, title };
+  const parent = getFlag(args.flags, 'parent');
+  if (parent !== undefined && parent !== true && parent !== 'root') {
+    body.parent_id = parent;
+  }
+  const content = await resolveContent(args.flags);
+  if (content !== undefined) body.content = content;
+  const out = await request('POST', '/api/notes', body);
+  printJSON({ id: out.id });
+}
+
+async function cmdNotesRename(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: notes:rename ID --title "Y"');
+  const title = requireFlag(args.flags, 'title');
+  await request('PATCH', `/api/notes/${id}`, { title });
+  printJSON({ ok: true });
+}
+
+async function cmdNotesRead(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: notes:read ID');
+  const out = await request('GET', `/api/notes/${id}`);
+  process.stdout.write(out.content ?? '');
+  if (!String(out.content ?? '').endsWith('\n')) {
+    process.stdout.write('\n');
+  }
+}
+
+async function cmdNotesWrite(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: notes:write ID --content "..." | --file PATH | --content -');
+  const content = await resolveContent(args.flags);
+  if (content === undefined) {
+    fail('missing_content', 'Provide --content "..." (or "-" for stdin) or --file PATH');
+  }
+  await request('PUT', `/api/notes/${id}`, { content });
+  printJSON({ ok: true });
+}
+
+async function cmdNodesMove(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: nodes:move ID [--to-workspace ID] [--to-parent ID|root] [--index N]');
+  const body = {};
+  const toWs = getFlag(args.flags, 'to-workspace');
+  if (toWs !== undefined && toWs !== true) body.to_workspace_id = toWs;
+  const toParent = getFlag(args.flags, 'to-parent');
+  if (toParent !== undefined && toParent !== true) {
+    body.to_parent_id = toParent === 'root' ? null : toParent;
+  }
+  const index = getFlag(args.flags, 'index');
+  if (index !== undefined && index !== true) {
+    const n = parseInt(index, 10);
+    if (Number.isNaN(n)) fail('bad_index', '--index must be an integer');
+    body.index = n;
+  }
+  await request('POST', `/api/nodes/${id}/move`, body);
+  printJSON({ ok: true });
+}
+
+async function cmdNodesDelete(args) {
+  const id = args.positional[0];
+  if (!id) fail('missing_arg', 'Usage: <type>:delete ID');
+  await request('DELETE', `/api/nodes/${id}`);
+  printJSON({ ok: true });
+}
+
+// ---------- Content resolution (--content / --file / stdin) ----------
+
+async function resolveContent(flags) {
+  const file = getFlag(flags, 'file');
+  if (file !== undefined && file !== true) {
+    if (file === '-') return await readStdin();
+    try {
+      return fs.readFileSync(file, 'utf8');
+    } catch (e) {
+      fail('file_unreadable', `Could not read ${file}: ${e.message}`);
+    }
+  }
+  const content = getFlag(flags, 'content');
+  if (content === undefined) return undefined;
+  if (content === true) fail('missing_content', '--content requires a value (or "-" for stdin)');
+  if (content === '-') return await readStdin();
+  return content;
+}
+
+// ---------- Help ----------
+
+const HELP = `arcmark.js — organize bookmarks, folders, and notes in the Arcmark macOS app.
+
+Usage:
+  arcmark.js <command> [args] [flags]
+
+State:
+  state                                Dump the full AppState JSON.
+  tree WORKSPACE_ID                    Dump a single workspace tree.
+
+Workspaces (cannot be deleted by the agent):
+  workspaces:list
+  workspaces:create        --name "X" [--color NAME]
+  workspaces:rename ID     --name "Y"
+  workspaces:set-color ID  --color NAME
+
+Folders:
+  folders:create   --workspace ID [--parent ID|root] --name "X" [--expanded true|false]
+  folders:rename   ID  --name "Y"
+  folders:delete   ID
+
+Links:
+  links:create     --workspace ID [--parent ID|root] --url URL [--title T]
+  links:rename     ID  --title "Y"
+  links:set-url    ID  --url URL
+  links:delete     ID
+
+Notes:
+  notes:create     --workspace ID [--parent ID|root] --title T [--content "..." | --file PATH | --content -]
+  notes:rename     ID  --title "Y"
+  notes:read       ID
+  notes:write      ID  --content "..." | --file PATH | --content -
+  notes:delete     ID
+
+Generic:
+  nodes:move       ID [--to-workspace ID] [--to-parent ID|root] [--index N]
+  nodes:delete     ID
+
+Color names: Blush, Apricot, Butter, Leaf, Mint, Sky, Periwinkle, Lavender
+(also accepts the raw enum cases ember, ruby, coral, tangerine, moss, ocean, indigo, graphite).
+
+Endpoint file: ${ENDPOINT_FILE}
+`;
+
+function cmdHelp() {
+  process.stdout.write(HELP);
+}
+
+// ---------- Entry ----------
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0) {
+    cmdHelp();
+    process.exit(0);
+  }
+  const command = argv[0];
+  const handler = COMMANDS[command];
+  if (!handler) {
+    fail('unknown_command', `Unknown command: ${command}`, { hint: 'Run `arcmark.js help` for the full list.' });
+  }
+  const args = parseArgs(argv.slice(1));
+  try {
+    await handler(args);
+  } catch (e) {
+    fail('internal_error', e.message || String(e));
+  }
+}
+
+main();

--- a/skills/arcmark/scripts/arcmark.js
+++ b/skills/arcmark/scripts/arcmark.js
@@ -164,6 +164,7 @@ const COMMANDS = {
   'tree': cmdTree,
 
   'workspaces:list': cmdWorkspacesList,
+  'workspaces:current': cmdWorkspacesCurrent,
   'workspaces:create': cmdWorkspacesCreate,
   'workspaces:rename': cmdWorkspacesRename,
   'workspaces:set-color': cmdWorkspacesSetColor,
@@ -202,6 +203,15 @@ async function cmdTree(args) {
 async function cmdWorkspacesList() {
   const out = await request('GET', '/api/workspaces');
   printJSON(out.workspaces || []);
+}
+
+async function cmdWorkspacesCurrent() {
+  const out = await request('GET', '/api/workspaces/current');
+  printJSON({
+    selected: out.selected === true,
+    settingsSelected: out.settingsSelected === true,
+    workspace: out.workspace ?? null,
+  });
 }
 
 async function cmdWorkspacesCreate(args) {
@@ -383,6 +393,7 @@ State:
 
 Workspaces (cannot be deleted by the agent):
   workspaces:list
+  workspaces:current                   Workspace currently visible in the app.
   workspaces:create        --name "X" [--color NAME]
   workspaces:rename ID     --name "Y"
   workspaces:set-color ID  --color NAME


### PR DESCRIPTION
## Summary
- Adds a localhost HTTP agent API to `NoteServer` (workspaces/folders/links/notes CRUD + node move/delete) and publishes the port via `~/Library/Application Support/Arcmark/agent-endpoint.json`.
- Refactors `AppModel` so mutations resolve the owning workspace from the node id, enabling cross-workspace operations without changing the current selection.
- Ships a zero-dependency Claude Code skill in `skills/arcmark/` (`SKILL.md` + `arcmark.js` CLI) plus README install instructions for `npx skills add` or copy-in.

## Test plan
- [ ] `swift test` passes (covers agent API round-trips, cross-workspace moves, delete cleanup, current-workspace endpoint, color validation)
- [ ] Launch the app, run `./skills/arcmark/scripts/arcmark.js workspaces:current` and confirm it returns the visible workspace
- [ ] Create a folder, link, and note via the CLI and confirm the sidebar updates live

🤖 Generated with [Claude Code](https://claude.com/claude-code)