### PR TITLE
feat(search): surface scheduled links inline while searching

### DIFF
--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -432,7 +432,11 @@ final class MainViewController: NSViewController {
             showWorkspaceContent()
             applyWorkspaceStyling()
             pinnedTabsView.update(pinnedLinks: model.currentWorkspace.pinnedLinks)
-            scheduledLinksAccordion.update(entries: model.scheduledLinks(in: model.currentWorkspace.id))
+            if searchCoordinator.isSearchActive {
+                scheduledLinksAccordion.isHidden = true
+            } else {
+                scheduledLinksAccordion.update(entries: model.scheduledLinks(in: model.currentWorkspace.id))
+            }
             let workspaceItems = model.currentWorkspace.items
             let visibleItems = searchCoordinator.isSearchActive
                 ? workspaceItems

--- a/Sources/ArcmarkCore/MainViewController.swift
+++ b/Sources/ArcmarkCore/MainViewController.swift
@@ -433,7 +433,10 @@ final class MainViewController: NSViewController {
             applyWorkspaceStyling()
             pinnedTabsView.update(pinnedLinks: model.currentWorkspace.pinnedLinks)
             scheduledLinksAccordion.update(entries: model.scheduledLinks(in: model.currentWorkspace.id))
-            let visibleItems = ScheduledLinkFiltering.hideScheduled(model.currentWorkspace.items)
+            let workspaceItems = model.currentWorkspace.items
+            let visibleItems = searchCoordinator.isSearchActive
+                ? workspaceItems
+                : ScheduledLinkFiltering.hideScheduled(workspaceItems)
             let filteredNodes = searchCoordinator.filter(nodes: visibleItems)
             let forceExpand = searchCoordinator.isSearchActive
             nodeListViewController.isSearchActive = searchCoordinator.isSearchActive


### PR DESCRIPTION
## Summary
- Bypass `ScheduledLinkFiltering.hideScheduled` when a search query is active so scheduled links reappear at their original tree location with the existing clock badge, making them findable by name.
- Hide the reminders accordion while searching to avoid duplicating those entries (it returns automatically once the query is cleared).

## Test plan
- [ ] Search for a scheduled link by name and confirm it appears inline with the clock badge.
- [ ] Clear the search and confirm the reminders accordion reappears with the correct entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)