### PR TITLE
Back up data.json before writes

### DIFF
--- a/Sources/ArcmarkCore/DataStore.swift
+++ b/Sources/ArcmarkCore/DataStore.swift
@@ -1,9 +1,20 @@
 import Foundation
+import os
 
 final class DataStore {
     private let fileManager = FileManager.default
     private let baseDirectory: URL
     private let dataURL: URL
+    private let logger = Logger(subsystem: "com.arcmark.app", category: "store")
+    private var hasBackedUpThisSession = false
+    private let backupKeepCount = 10
+    private let backupTimestampFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH-mm-ss-SSS"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
 
     init(baseDirectory: URL? = nil) {
         if let baseDirectory {
@@ -23,6 +34,8 @@ final class DataStore {
             return defaultState
         }
 
+        backupDataFileIfNeeded()
+
         do {
             let data = try Data(contentsOf: dataURL)
             let decoder = JSONDecoder()
@@ -36,6 +49,7 @@ final class DataStore {
     }
 
     func save(_ state: AppState) {
+        backupDataFileIfNeeded()
         ensureDirectories()
         do {
             let encoder = JSONEncoder()
@@ -69,6 +83,58 @@ final class DataStore {
 
     func agentEndpointFileURL() -> URL {
         baseDirectory.appendingPathComponent("agent-endpoint.json")
+    }
+
+    /// Copies data.json into `Backups/` once per session, before this process
+    /// first writes to it. Skips the copy when the file is byte-identical to the
+    /// newest existing backup so repeated relaunches don't rotate away the last
+    /// good backup. Keeps the `backupKeepCount` most recent backups.
+    private func backupDataFileIfNeeded() {
+        guard !hasBackedUpThisSession else { return }
+        hasBackedUpThisSession = true
+
+        guard fileManager.fileExists(atPath: dataURL.path) else { return }
+
+        do {
+            let data = try Data(contentsOf: dataURL)
+            let backupsURL = backupsDirectory()
+            if let newest = sortedBackupURLs(in: backupsURL).last,
+               let newestData = try? Data(contentsOf: newest),
+               newestData == data {
+                return
+            }
+            let timestamp = backupTimestampFormatter.string(from: Date())
+            let backupURL = backupsURL.appendingPathComponent("data-\(timestamp).json")
+            try data.write(to: backupURL, options: [.atomic])
+            pruneBackups(in: backupsURL)
+        } catch {
+            logger.error("Failed to back up data.json: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func backupsDirectory() -> URL {
+        let backupsURL = baseDirectory.appendingPathComponent("Backups", isDirectory: true)
+        if !fileManager.fileExists(atPath: backupsURL.path) {
+            try? fileManager.createDirectory(at: backupsURL, withIntermediateDirectories: true)
+        }
+        return backupsURL
+    }
+
+    /// Backup filenames are fixed-width UTC timestamps, so lexicographic order
+    /// equals chronological order.
+    private func sortedBackupURLs(in backupsURL: URL) -> [URL] {
+        let contents = (try? fileManager.contentsOfDirectory(at: backupsURL, includingPropertiesForKeys: nil)) ?? []
+        return contents
+            .filter { $0.lastPathComponent.hasPrefix("data-") && $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    private func pruneBackups(in backupsURL: URL) {
+        let backups = sortedBackupURLs(in: backupsURL)
+        guard backups.count > backupKeepCount else { return }
+        for url in backups.dropLast(backupKeepCount) {
+            try? fileManager.removeItem(at: url)
+        }
     }
 
     private func ensureDirectories() {

--- a/Sources/ArcmarkCore/DataStore.swift
+++ b/Sources/ArcmarkCore/DataStore.swift
@@ -42,9 +42,11 @@ final class DataStore {
             let state = try decoder.decode(AppState.self, from: data)
             return state
         } catch {
-            let fallback = Self.defaultState()
-            save(fallback)
-            return fallback
+            // Leave data.json untouched so a newer-schema or corrupt file can be
+            // recovered (e.g. by re-upgrading); it is only overwritten on the
+            // first actual mutation, and the pre-decode backup exists by then.
+            logger.error("Failed to decode data.json; leaving file untouched: \(error.localizedDescription, privacy: .public)")
+            return Self.defaultState()
         }
     }
 

--- a/Tests/ArcmarkTests/DataStoreBackupTests.swift
+++ b/Tests/ArcmarkTests/DataStoreBackupTests.swift
@@ -40,6 +40,21 @@ final class DataStoreBackupTests: XCTestCase {
         XCTAssertEqual(backupData, liveData)
     }
 
+    func testCorruptFileIsPreservedAndBackedUpNotOverwritten() throws {
+        let directory = makeTempDirectory()
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let corruptBytes = Data("not json".utf8)
+        try corruptBytes.write(to: dataURL(in: directory))
+
+        let state = DataStore(baseDirectory: directory).load()
+
+        XCTAssertEqual(state.workspaces.map(\.name), ["Inbox"])
+        XCTAssertEqual(try Data(contentsOf: dataURL(in: directory)), corruptBytes)
+        let backups = backupURLs(in: directory)
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(try Data(contentsOf: backups[0]), corruptBytes)
+    }
+
     func testRelaunchWithUnchangedDataDoesNotDuplicateBackup() {
         let directory = makeTempDirectory()
         DataStore(baseDirectory: directory).save(makeState(name: "A"))

--- a/Tests/ArcmarkTests/DataStoreBackupTests.swift
+++ b/Tests/ArcmarkTests/DataStoreBackupTests.swift
@@ -1,0 +1,93 @@
+import XCTest
+@testable import ArcmarkCore
+
+final class DataStoreBackupTests: XCTestCase {
+    private func makeTempDirectory() -> URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+    }
+
+    private func makeState(name: String) -> AppState {
+        let workspace = Workspace(id: UUID(), name: name, colorId: .defaultColor(), items: [])
+        return AppState(schemaVersion: 1, workspaces: [workspace], selectedWorkspaceId: workspace.id, isSettingsSelected: false)
+    }
+
+    private func dataURL(in directory: URL) -> URL {
+        directory.appendingPathComponent("data.json")
+    }
+
+    private func backupsDirectory(in directory: URL) -> URL {
+        directory.appendingPathComponent("Backups")
+    }
+
+    private func backupURLs(in directory: URL) -> [URL] {
+        let backups = backupsDirectory(in: directory)
+        let contents = (try? FileManager.default.contentsOfDirectory(at: backups, includingPropertiesForKeys: nil)) ?? []
+        return contents
+            .filter { $0.lastPathComponent.hasPrefix("data-") && $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    func testLoadCreatesBackup() throws {
+        let directory = makeTempDirectory()
+        DataStore(baseDirectory: directory).save(makeState(name: "A"))
+
+        _ = DataStore(baseDirectory: directory).load()
+
+        let backups = backupURLs(in: directory)
+        XCTAssertEqual(backups.count, 1)
+        let backupData = try Data(contentsOf: backups[0])
+        let liveData = try Data(contentsOf: dataURL(in: directory))
+        XCTAssertEqual(backupData, liveData)
+    }
+
+    func testRelaunchWithUnchangedDataDoesNotDuplicateBackup() {
+        let directory = makeTempDirectory()
+        DataStore(baseDirectory: directory).save(makeState(name: "A"))
+
+        _ = DataStore(baseDirectory: directory).load()
+        _ = DataStore(baseDirectory: directory).load()
+
+        XCTAssertEqual(backupURLs(in: directory).count, 1)
+    }
+
+    func testBackupRotationKeepsTenMostRecent() {
+        let directory = makeTempDirectory()
+        var allNames = Set<String>()
+
+        // Each fresh instance backs up the previous on-disk state before writing
+        // a distinct new one; the final load() backs up the 12th state.
+        for index in 0..<12 {
+            DataStore(baseDirectory: directory).save(makeState(name: "Workspace \(index)"))
+            backupURLs(in: directory).forEach { allNames.insert($0.lastPathComponent) }
+            Thread.sleep(forTimeInterval: 0.005)
+        }
+        _ = DataStore(baseDirectory: directory).load()
+        backupURLs(in: directory).forEach { allNames.insert($0.lastPathComponent) }
+
+        XCTAssertEqual(allNames.count, 12)
+        let remaining = backupURLs(in: directory).map(\.lastPathComponent)
+        XCTAssertEqual(remaining.count, 10)
+        XCTAssertEqual(Set(remaining), Set(allNames.sorted().suffix(10)))
+    }
+
+    func testSaveWithoutPriorLoadStillBacksUp() throws {
+        let directory = makeTempDirectory()
+        DataStore(baseDirectory: directory).save(makeState(name: "A"))
+        let originalData = try Data(contentsOf: dataURL(in: directory))
+
+        DataStore(baseDirectory: directory).save(makeState(name: "B"))
+
+        let backups = backupURLs(in: directory)
+        XCTAssertEqual(backups.count, 1)
+        XCTAssertEqual(try Data(contentsOf: backups[0]), originalData)
+    }
+
+    func testFirstLaunchCreatesNoBackup() {
+        let directory = makeTempDirectory()
+
+        _ = DataStore(baseDirectory: directory).load()
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: dataURL(in: directory).path))
+        XCTAssertTrue(backupURLs(in: directory).isEmpty)
+    }
+}


### PR DESCRIPTION
Adds a one-per-session backup of data.json before the datastore first reads or writes it, with duplicate suppression and rotation to the 10 newest backups. Preserves unreadable or newer-schema data.json files on decode failure instead of immediately overwriting them with defaults. Adds datastore backup tests for load/save backup creation, corrupt file preservation, duplicate suppression, rotation, and first-launch behavior.\n\nTests: swift test --filter DataStoreBackupTests passed; full swift test still fails on existing NoteServerTests.testGetReturnsNoteJSON unrelated to this diff.